### PR TITLE
workflow for automatic github release

### DIFF
--- a/.github/workflows/pubish-to-pypi.yml
+++ b/.github/workflows/pubish-to-pypi.yml
@@ -1,0 +1,31 @@
+---
+name: PyPI
+on: push
+jobs:
+  build-n-publish:
+    name: Build and publish maketables Python 🐍 distributions 📦 to PyPI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install pypa/build
+        run: >-
+          python -m
+          pip install
+          build
+          --user
+      - name: Build a binary wheel and a source tarball
+        run: >-
+          python -m
+          build
+          --sdist
+          --wheel
+          --outdir dist/
+      - name: Publish distribution 📦 to PyPI
+        if: startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN_MAKETABLES }}


### PR DESCRIPTION
This CI workflow triggers a PyPi release whenever we release a new [version via GitHub](https://github.com/py-econometrics/maketables/releases). It is taken from [optimagic](https://github.com/optimagic-dev/optimagic/blob/main/.github/workflows/publish-to-pypi.yml). 

What we'd still have to do - create the API token and copy it to PyPi. 

