### PR TITLE
Allow BTable group to accept multiple columns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,8 @@ _site/
 
 **/*.quarto_ipynb
 _freeze/
+
+# continue dev LLM instructions
+.continue/
+.gitmodules
+AGENTS.md

--- a/reference/BTable.qmd
+++ b/reference/BTable.qmd
@@ -27,7 +27,7 @@ Balancing table: descriptive stats by group + per-variable p-values from group t
 Inherits DTable to build the stats table, then adds a 'p-value' column:
 - For 2 groups: p-value of the single group indicator (t test).
 - For >2 groups: joint Wald test that all group indicators are zero.
-You can add fixed_effects and specify the `vcov` option, for instance 
+You can add fixed_effects and specify the `vcov` option, for instance
 to implement clustering (see pyfixest documentation).
 
 ## Parameters {.doc-section .doc-section-parameters}
@@ -36,7 +36,7 @@ to implement clustering (see pyfixest documentation).
 |------------------|--------------------------|----------------------------------------------------------------------------------------------------------|------------|
 | df               | pd.DataFrame             | Source data.                                                                                             | _required_ |
 | vars             | list\[str\]              | Variables to include.                                                                                    | _required_ |
-| group            | str                      | Grouping column in df.                                                                                   | _required_ |
+| group            | str \| list\[str\]       | Grouping column(s) in df.                                                                                | _required_ |
 | labels           | dict                     | Variable labels (used for display and in notes).                                                         | `None`     |
 | digits           | int                      | Rounding for stats in the DTable. Default 2.                                                             | `2`        |
 | pdigits          | int                      | Rounding for p-values. Default 3.                                                                        | `3`        |

--- a/src/maketables/btable.py
+++ b/src/maketables/btable.py
@@ -1,11 +1,10 @@
-from typing import Dict, List, Optional, Union
-
 import numpy as np
 import pandas as pd
 
 # Optional imports
 try:
     import pyfixest as pf
+
     HAS_PYFIXEST = True
 except ImportError:
     HAS_PYFIXEST = False
@@ -20,7 +19,7 @@ class BTable(DTable):
     Inherits DTable to build the stats table, then adds a 'p-value' column:
     - For 2 groups: p-value of the single group indicator (t test).
     - For >2 groups: joint Wald test that all group indicators are zero.
-    You can add fixed_effects and specify the `vcov` option, for instance 
+    You can add fixed_effects and specify the `vcov` option, for instance
     to implement clustering (see pyfixest documentation).
 
     Parameters
@@ -29,8 +28,8 @@ class BTable(DTable):
         Source data.
     vars : list[str]
         Variables to include.
-    group : str
-        Grouping column in df.
+    group : str | list[str]
+        Grouping column(s) in df.
     labels : dict, optional
         Variable labels (used for display and in notes).
     digits : int, optional
@@ -60,17 +59,17 @@ class BTable(DTable):
     def __init__(
         self,
         df: pd.DataFrame,
-        vars: List[str],
-        group: str,
+        vars: list[str],
+        group: str | list[str],
         *,
-        labels: Optional[Dict[str, str]] = None,
+        labels: dict[str, str] | None = None,
         digits: int = 2,
         pdigits: int = 3,
-        vcov: Union[str, Dict[str, str]] = "iid",
-        fixed_effects: Optional[List[str]] = None,
-        stats: Optional[List[str]] = None,
-        stats_labels: Optional[Dict[str, str]] = None,
-        format_spec: Optional[Dict[Union[str, tuple], str]] = None,
+        vcov: str | dict[str, str] = "iid",
+        fixed_effects: list[str] | None = None,
+        stats: list[str] | None = None,
+        stats_labels: dict[str, str] | None = None,
+        format_spec: dict[str | tuple, str] | None = None,
         hide_stats: bool = False,
         counts_row_below: bool = False,
         observed: bool = False,
@@ -85,18 +84,22 @@ class BTable(DTable):
                 "  pip install maketables[pystata]"
             )
 
-        assert group in df.columns, f"group column '{group}' not in DataFrame."
+        group_cols = [group] if isinstance(group, str) else list(group)
+        assert group_cols, "group must contain at least one column."
+        assert all(col in df.columns for col in group_cols), (
+            "group must be a column or list of columns in the DataFrame."
+        )
         for v in vars:
             assert v in df.columns, f"Variable '{v}' not in DataFrame."
 
         stats = ["mean", "std"] if stats is None else list(stats)
-    
+
         # Build the descriptive stats table via DTable
         super().__init__(
             df=df,
             vars=vars,
             stats=stats,
-            bycol=[group],
+            bycol=group_cols,
             byrow=None,
             labels=labels,
             stats_labels=stats_labels,
@@ -110,7 +113,20 @@ class BTable(DTable):
         )
 
         # Compute p-values per variable from a group-effects regression
-        n_groups = df[group].nunique()
+        pvalue_df = df
+        pvalue_group = group_cols[0]
+        if len(group_cols) > 1:
+            pvalue_df = df.copy()
+            pvalue_group = "__maketables_btable_group"
+            while pvalue_group in pvalue_df.columns:
+                pvalue_group = f"{pvalue_group}_"
+
+            group_values = pvalue_df[group_cols].astype("string")
+            interaction = group_values.fillna("").agg(" | ".join, axis=1)
+            interaction[group_values.isna().any(axis=1)] = pd.NA
+            pvalue_df[pvalue_group] = interaction
+
+        n_groups = pvalue_df[pvalue_group].nunique()
         pvals = pd.Series(index=self.df.index, dtype=str)
 
         fe_suffix = ""
@@ -118,8 +134,8 @@ class BTable(DTable):
             fe_suffix = f" | {'.'.join(fixed_effects)}"
 
         for i, var in enumerate(vars):
-            formula = f"{var} ~ i({group}){fe_suffix}"
-            model = pf.feols(formula, data=df, vcov=vcov)
+            formula = f"{var} ~ i({pvalue_group}){fe_suffix}"
+            model = pf.feols(formula, data=pvalue_df, vcov=vcov)
 
             if n_groups == 2:
                 # p-value of the single group indicator
@@ -173,13 +189,13 @@ class BTable(DTable):
                 clusters = []
                 for k, v in vcov.items():
                     if k in {"CRV1", "CRV3"}:
-                        clusters.append(labels.get(v, v))
+                        clusters.append((labels or {}).get(v, v))
                 if clusters:
                     se_str = "standard errors clustered on " + ", ".join(clusters)
 
             fe_str = ""
             if fixed_effects:
-                fe_str = ", ".join(labels.get(fx, fx) for fx in fixed_effects)
+                fe_str = ", ".join((labels or {}).get(fx, fx) for fx in fixed_effects)
 
             if fe_str and se_str:
                 chunks.append(

--- a/src/maketables/dtable.py
+++ b/src/maketables/dtable.py
@@ -1,5 +1,3 @@
-from typing import ClassVar
-
 import numpy as np
 import pandas as pd
 
@@ -99,14 +97,18 @@ class DTable(MTable):
             # normalize to plain python strings for reliable lookup
             var = str(var) if var is not None else None
             stat = str(stat) if stat is not None else None
-            #print("FORMAT_LOOKUP:", repr(var), repr(stat))
+            # print("FORMAT_LOOKUP:", repr(var), repr(stat))
             if isinstance(self.format_specs, dict):
                 # most specific first
                 if (var, stat) in self.format_specs:
                     return self.format_specs[(var, stat)]
-                if var in self.format_specs and not isinstance(self.format_specs[var], dict):
+                if var in self.format_specs and not isinstance(
+                    self.format_specs[var], dict
+                ):
                     return self.format_specs[var]
-                if stat in self.format_specs and not isinstance(self.format_specs[stat], dict):
+                if stat in self.format_specs and not isinstance(
+                    self.format_specs[stat], dict
+                ):
                     return self.format_specs[stat]
             return None
 
@@ -148,7 +150,9 @@ class DTable(MTable):
             if byrow is not None:
                 counts_row_below = False
             elif "count" not in stats:
-                stats = ["count"] + stats
+                stats = ["count", *stats]
+
+        binary_vars = {var for var in vars if _is_binary_series(df[var])}
 
         def mean_std(x):
             # Use get_format_spec for mean and std
@@ -161,6 +165,7 @@ class DTable(MTable):
                 newline=False,
                 format_specs={"mean": mean_fmt, "std": std_fmt},
                 format_number_func=self._format_number,
+                suppress_std=var_name in binary_vars,
             )
 
         def mean_newline_std(x):
@@ -174,6 +179,7 @@ class DTable(MTable):
                 newline=True,
                 format_specs={"mean": mean_fmt, "std": std_fmt},
                 format_number_func=self._format_number,
+                suppress_std=var_name in binary_vars,
             )
 
         custom_funcs = {"mean_std": mean_std, "mean_newline_std": mean_newline_std}
@@ -214,11 +220,15 @@ class DTable(MTable):
                 if stat_name in ["mean_std", "mean_newline_std"]:
                     continue
                 # Only format numeric columns or when a format_spec exists for this stat or any var
-                if not (pd.api.types.is_numeric_dtype(res[col]) or stat_name in self.format_specs or any(str(v) in self.format_specs for v in res.index)):
+                if not (
+                    pd.api.types.is_numeric_dtype(res[col])
+                    or stat_name in self.format_specs
+                    or any(str(v) in self.format_specs for v in res.index)
+                ):
                     continue
                 # Format each cell using the row index as the variable name
                 formatted = []
-                for var_label, val in zip(res.index, res[col]):
+                for var_label, val in zip(res.index, res[col], strict=False):
                     var_name = str(var_label) if var_label is not None else None
                     fmt = get_format_spec(var_name, stat_name)
                     formatted.append(self._format_number(val, fmt, digits=digits))
@@ -247,11 +257,19 @@ class DTable(MTable):
                     counts_row_below = False
 
             for col in res.columns:
-                stat_name = col[-1] if isinstance(res.columns, pd.MultiIndex) else (res[col].name if hasattr(res[col], "name") else col)
+                stat_name = (
+                    col[-1]
+                    if isinstance(res.columns, pd.MultiIndex)
+                    else (res[col].name if hasattr(res[col], "name") else col)
+                )
                 var_name = col[0] if isinstance(res.columns, pd.MultiIndex) else col
                 if stat_name in ["mean_std", "mean_newline_std"]:
                     continue
-                elif (pd.api.types.is_numeric_dtype(res[col])) or stat_name in self.format_specs or var_name in self.format_specs:
+                elif (
+                    (pd.api.types.is_numeric_dtype(res[col]))
+                    or stat_name in self.format_specs
+                    or var_name in self.format_specs
+                ):
                     res[col] = res[col].apply(
                         lambda x, sn=stat_name, vn=var_name: self._format_number(
                             x, get_format_spec(vn, sn), digits=digits
@@ -294,10 +312,11 @@ class DTable(MTable):
         # Call MTable constructor with processed table and metadata
         super().__init__(res, notes=notes, rgroup_display=rgroup_display, **kwargs)
 
-    def _format_number(self, x: float, format_spec: str | None = None, digits: int = 2) -> str:
+    def _format_number(
+        self, x: float, format_spec: str | None = None, digits: int = 2
+    ) -> str:
         """Format a number with optional format specifier or sensible default."""
         import pandas as pd
-        import numpy as np
 
         if pd.isna(x) or (isinstance(x, float) and np.isnan(x)):
             return "-"
@@ -306,23 +325,22 @@ class DTable(MTable):
             abs_x = abs(x)
             if abs_x < 0.001 and abs_x > 0:
                 return f"{x:.6f}".rstrip("0").rstrip(".")
-            elif abs_x < 1:
-                return f"{x:.{digits}f}"
-            elif abs_x < 1000:
+            elif abs_x < 1 or abs_x < 1000:
                 return f"{x:.{digits}f}"
             elif abs_x >= 10000:
                 return f"{x:,.0f}"
             elif abs_x >= 1000:
                 if abs(x - round(x)) < 1e-10:
-                    return f"{int(round(x)):,}"
+                    return f"{round(x):,}"
                 else:
                     return f"{x:,.2f}"
             else:
                 return f"{x:.{digits}f}"
         try:
             if format_spec == "d":
-                return f"{int(round(x)):d}"
-            return f"{x:{format_spec}}"
+                return f"{round(x):d}"
+            else:
+                return f"{x:{format_spec}}"
         except (ValueError, TypeError):
             # fallback to sensible default
             return self._format_number(x, None, digits=digits)
@@ -353,26 +371,39 @@ def _relabel_index(index, labels=None, stats_labels=None):
     return index
 
 
+def _is_binary_series(data: pd.Series) -> bool:
+    """Return True for numeric/bool series with two distinct non-missing values."""
+    return (
+        pd.api.types.is_numeric_dtype(data) or pd.api.types.is_bool_dtype(data)
+    ) and data.nunique(dropna=True) == 2
+
+
 def _format_mean_std(
     data: pd.Series,
     digits: int = 2,
     newline: bool = True,
     format_specs: dict | None = None,
     format_number_func=None,
+    suppress_std: bool = False,
 ) -> str:
     """
-    Calculate the mean and standard deviation of a pandas Series and return as a string of the format "mean /n (std)".
+    Calculate the mean and standard deviation of a pandas Series and return
+    as a string.
 
     Parameters
     ----------
     data : pd.Series
         The pandas Series for which to calculate the mean and standard deviation.
     digits : int, optional
-        The number of decimal places to round the mean and standard deviation to. The default is 2.
+        The number of decimal places to round the mean and standard deviation to.
+        The default is 2.
     newline : bool, optional
-        Whether to add a newline character between the mean and standard deviation. The default is True.
+        Whether to add a newline character between the mean and standard deviation.
+        The default is True.
     format_specs : dict, optional
         Format specifications for mean and std. Keys should be 'mean' and 'std'.
+    suppress_std : bool, optional
+        Whether to return only the formatted mean. The default is False.
 
     Returns
     -------
@@ -386,8 +417,18 @@ def _format_mean_std(
         mean_str = f"{mean:.{digits}f}"
         std_str = f"{std:.{digits}f}"
     else:
-        mean_str = format_number_func(mean, format_specs.get("mean") if format_specs else None, digits)
-        std_str = format_number_func(std, format_specs.get("std") if format_specs else None, digits)
+        mean_str = format_number_func(
+            mean,
+            format_specs.get("mean") if format_specs else None,
+            digits,
+        )
+        std_str = format_number_func(
+            std,
+            format_specs.get("std") if format_specs else None,
+            digits,
+        )
+    if suppress_std:
+        return mean_str
     if newline:
         return f"{mean_str}\n({std_str})"
     else:

--- a/src/maketables/mtable.py
+++ b/src/maketables/mtable.py
@@ -1,5 +1,7 @@
 import os
+import json
 from typing import ClassVar
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -104,7 +106,14 @@ class MTable:
     DEFAULT_SAVE_PATH = None  # can be string or dict
     DEFAULT_REPLACE = False
     DEFAULT_SAVE_TYPE = "html"
-    ADMISSIBLE_TYPES: ClassVar[list[str]] = ["gt", "tex", "typst", "docx", "html"]
+    ADMISSIBLE_TYPES: ClassVar[list[str]] = [
+        "gt",
+        "tex",
+        "typst",
+        "docx",
+        "html",
+        "quarto",
+    ]
     ADMISSIBLE_SAVE_TYPES: ClassVar[list[str]] = ["tex", "typst", "docx", "html"]
 
     # Default TeX style (override globally via MTable.DEFAULT_TEX_STYLE.update({...})
@@ -246,6 +255,10 @@ class MTable:
         # No other style/render defaults here; handled in output methods
         **kwargs,
     ):
+        requested_type = kwargs.pop("_requested_type", None)
+        if requested_type is None:
+            requested_type = kwargs.pop("type", None)
+
         assert isinstance(df, pd.DataFrame), "df must be a pandas DataFrame."
         assert not isinstance(df.index, pd.MultiIndex) or df.index.nlevels <= 2, (
             "Row index can have at most two levels."
@@ -256,6 +269,7 @@ class MTable:
         self.tab_label = tab_label
         self.rgroup_sep = rgroup_sep
         self.rgroup_display = rgroup_display
+        self._requested_type = requested_type
         if isinstance(default_paths, str):
             self.default_paths = dict.fromkeys(
                 self.ADMISSIBLE_SAVE_TYPES, default_paths
@@ -289,16 +303,65 @@ class MTable:
         """
         return translate_symbols(text, output_format)
 
+    def _resolve_quarto_output_type(self) -> str:
+        """
+        Resolve output type from Quarto execution context.
+
+        Returns
+        -------
+        str
+            One of: "html", "tex", "typst", "docx", or "gt" (fallback).
+        """
+        execute_info_path = os.environ.get("QUARTO_EXECUTE_INFO")
+        if not execute_info_path:
+            return "gt"
+
+        execute_info_file = Path(execute_info_path)
+        if not execute_info_file.exists() or not execute_info_file.is_file():
+            return "gt"
+
+        try:
+            with execute_info_file.open(encoding="utf-8") as f:
+                info = json.load(f)
+        except (OSError, json.JSONDecodeError, TypeError, ValueError):
+            return "gt"
+
+        identifier = info.get("format", {}).get("identifier", {})
+        base_format = str(identifier.get("base-format", "")).lower()
+        target_format = str(identifier.get("target-format", "")).lower()
+
+        def _map_format(fmt: str) -> str | None:
+            if fmt.startswith("html"):
+                return "html"
+            if fmt == "typst":
+                return "typst"
+            if fmt in {"latex", "pdf"}:
+                return "tex"
+            if fmt == "docx":
+                return "docx"
+            return None
+
+        # Prefer target format first: Quarto can report base-format=latex while
+        # rendering typst/docx, and target-format captures the actual backend.
+        for fmt in (target_format, base_format):
+            mapped = _map_format(fmt)
+            if mapped is not None:
+                return mapped
+
+        return "gt"
+
     def make(self, type: str | None = None, **kwargs):
         r"""
-        Create the output object of the table (either gt, tex, docx, or html).
+        Create the output object of the table (either gt, tex, typst, docx, html,
+        or quarto).
         If type is None, displays both HTML and LaTeX outputs for compatibility
         with both notebook viewing and Quarto rendering.
 
         Parameters
         ----------
         type : str, optional
-            The type of the output object ("gt", "tex", "typst", "docx", "html").
+            The type of the output object
+            ("gt", "tex", "typst", "docx", "html", "quarto").
         **kwargs : Further arguments forwarded to the respective output method when type is specified.
             - For type="tex" (LaTeX):
 
@@ -333,6 +396,10 @@ class MTable:
                 first_col_width, font_name, font_color_rgb, font_size_pt, notes_font_size_pt,
                 caption_font_name, caption_font_size_pt, caption_align, notes_align,
                 align_center_cells, border_*_rule_sz, cell_margins_dxa, table_style_name.
+                        - For type="quarto":
+
+                            - Reads QUARTO_EXECUTE_INFO and resolves target output format.
+                                If Quarto context is unavailable/invalid, falls back to GT.
 
         Returns
         -------
@@ -346,19 +413,23 @@ class MTable:
             class DualOutput:
                 """Display different outputs in notebook vs Quarto rendering."""
 
-                def __init__(self, notebook_html, quarto_latex):
+                def __init__(self, notebook_html, quarto_latex, quarto_typst):
                     self.notebook_html = notebook_html
                     self.quarto_latex = quarto_latex
+                    self.quarto_typst = quarto_typst
 
                 def _repr_mimebundle_(self, include=None, exclude=None):
-                    return {
+                    bundle = {
                         "text/html": self.notebook_html,
+                        "text/typst": self.quarto_typst,
                         "text/latex": self.quarto_latex,
                     }
+                    return bundle
 
             # Generate both HTML and LaTeX outputs
             html_output = self._output_gt().as_raw_html()
             tex_output = self._output_tex()
+            typst_output = self._output_typst()
 
             # Add CSS to remove zebra striping if desired
             html_output = (
@@ -372,7 +443,7 @@ class MTable:
                 + html_output
             )
             # Create and display the dual output object
-            dual_output = DualOutput(html_output, tex_output)
+            dual_output = DualOutput(html_output, tex_output, typst_output)
             display(dual_output)
             return None
 
@@ -388,6 +459,34 @@ class MTable:
             return self._output_typst(**kwargs)
         elif type == "docx":
             return self._output_docx(**kwargs)
+        elif type == "quarto":
+            class QuartoRaw(str):
+                """String content with rich notebook renderers for Quarto backends."""
+
+                def __new__(cls, value: str, fmt: str):
+                    obj = super().__new__(cls, value)
+                    obj._fmt = fmt
+                    return obj
+
+                def _repr_mimebundle_(self, include=None, exclude=None):
+                    raw_block = f"```{{={self._fmt}}}\n{str(self)}\n```"
+                    bundle = {"text/markdown": raw_block}
+                    if self._fmt == "latex":
+                        bundle["text/latex"] = str(self)
+                    elif self._fmt == "typst":
+                        bundle["text/typst"] = str(self)
+                    return bundle
+
+            resolved_type = self._resolve_quarto_output_type()
+            if resolved_type == "html":
+                return self._output_gt(**kwargs).as_raw_html()
+            elif resolved_type == "tex":
+                return QuartoRaw(self._output_tex(**kwargs), "latex")
+            elif resolved_type == "typst":
+                return QuartoRaw(self._output_typst(**kwargs), "typst")
+            elif resolved_type == "docx":
+                return self._output_docx(**kwargs)
+            return self._output_gt(**kwargs)
         else:
             return self._output_gt(**kwargs).as_raw_html()
 
@@ -1622,8 +1721,9 @@ class MTable:
 
         # Add bottom rule, then optional notes row below the rule, then close table
         lines.append(f"  table.hline(stroke: 0.08em),")
-        if self.notes is not None:
-            notes_escaped = self._escape_typst(self.notes, escape_asterisks=True)
+        notes_text = "" if self.notes is None else str(self.notes).strip()
+        if notes_text:
+            notes_escaped = self._escape_typst(notes_text, escape_asterisks=True)
             lines.append(f"  [#table.cell(colspan: {total_cols})[#text(size: {notes_fontsize})[{notes_escaped}]]],")
         lines.append(")")
 
@@ -1821,43 +1921,47 @@ class MTable:
 
         return gt
 
-    def __repr__(self):
-        """
-        Return a representation of the table.
-
-        In notebook environments, this will automatically display the table
-        with dual output format (HTML in notebooks, LaTeX in Quarto) without
-        requiring an explicit call to make().
-
-        Returns
-        -------
-        str
-            An empty string
-        """
-
-        # For dual output, we need to handle parameters differently
-        # Create dual output object for notebook/Quarto compatibility
-        class DualOutput:
-            """Display different outputs in notebook vs Quarto rendering."""
-
-            def __init__(self, notebook_html, quarto_latex):
-                self.notebook_html = notebook_html
-                self.quarto_latex = quarto_latex
-
-            def _repr_mimebundle_(self, include=None, exclude=None):
-                return {
-                    "text/html": self.notebook_html,
-                    "text/latex": self.quarto_latex,
-                }
-
-        # Generate both HTML and LaTeX outputs with their specific styles
-        gt_style = self._display_styles.get("gt_style", {})
+    def _repr_mimebundle_(self, include=None, exclude=None):
+        """Return rich mime output for notebooks and Quarto."""
         tex_style = self._display_styles.get("tex_style", {})
+        typst_style = self._display_styles.get("typst_style", {})
+        gt_style = self._display_styles.get("gt_style", {})
 
+        # Quarto render path: emit a raw fenced block via markdown so pandoc
+        # reliably consumes backend-specific table code.
+        if os.environ.get("QUARTO_EXECUTE_INFO"):
+            resolved_type = self._resolve_quarto_output_type()
+            if resolved_type == "tex":
+                tex_output = self._output_tex(tex_style=tex_style)
+                raw_block = f"```{{=latex}}\n{tex_output}\n```"
+                return {"text/markdown": raw_block, "text/latex": tex_output}
+            if resolved_type == "typst":
+                typst_output = self._output_typst(typst_style=typst_style)
+                raw_block = f"```{{=typst}}\n{typst_output}\n```"
+                return {"text/markdown": raw_block, "text/typst": typst_output}
+            # For html or unknown formats (resolved_type="gt"), use fallback logic.
+            # If caller explicitly requested Quarto output, emit both raw backend
+            # blocks so either LaTeX or Typst render can consume the matching one.
+            if self._requested_type == "quarto":
+                tex_output = self._output_tex(tex_style=tex_style)
+                typst_output = self._output_typst(typst_style=typst_style)
+                raw_block = (
+                    f"```{{=latex}}\n{tex_output}\n```\n"
+                    f"```{{=typst}}\n{typst_output}\n```"
+                )
+                return {
+                    "text/markdown": raw_block,
+                    "text/typst": typst_output,
+                    "text/latex": tex_output,
+                }
+            # Default Quarto fallback: emit HTML (for notebooks or when type not specified)
+            if resolved_type in ("html", "gt"):
+                return {"text/html": self._output_gt(gt_style=gt_style).as_raw_html()}
+            # Catch-all for any other resolved type
+            return {"text/html": self._output_gt(gt_style=gt_style).as_raw_html()}
+
+        # Interactive notebook path: show HTML while also providing TeX/Typst.
         html_output = self._output_gt(gt_style=gt_style).as_raw_html()
-        tex_output = self._output_tex(tex_style=tex_style)
-
-        # Add CSS to remove zebra striping if desired
         html_output = (
             """
         <style>
@@ -1868,11 +1972,22 @@ class MTable:
         """
             + html_output
         )
-        # Create and display the dual output object
+        return {
+            "text/html": html_output,
+            "text/typst": self._output_typst(typst_style=typst_style),
+            "text/latex": self._output_tex(tex_style=tex_style),
+        }
+
+    def _ipython_display_(self):
+        """Display hook used by IPython/Jupyter for last-expression rendering."""
         from IPython.display import display
 
-        dual_output = DualOutput(html_output, tex_output)
-        display(dual_output)
+        # Always display the full MIME bundle so Quarto/notebooks get all formats.
+        # _repr_mimebundle_() handles QUARTO_EXECUTE_INFO detection internally.
+        display(self._repr_mimebundle_(), raw=True)
+
+    def __repr__(self):
+        """Return plain-text fallback representation for rich display contexts."""
         return ""
 
     def __call__(self, type=None, **kwargs):

--- a/tests/api/__snapshots__/test_formatting.ambr
+++ b/tests/api/__snapshots__/test_formatting.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: TestETableCoefFormat.test_coef_fmt_all_stats_html
+# name: TestETableCoefFormat.test_coef_fmt[all_stats-html]
   '''
   <div id="STABLE_ID" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
   <style>
@@ -100,7 +100,7 @@
           
   '''
 # ---
-# name: TestETableCoefFormat.test_coef_fmt_all_stats_latex
+# name: TestETableCoefFormat.test_coef_fmt[all_stats-latex]
   '''
   \begin{threeparttable}
   \begingroup
@@ -135,7 +135,7 @@
   \end{threeparttable}
   '''
 # ---
-# name: TestETableCoefFormat.test_coef_fmt_all_stats_typst
+# name: TestETableCoefFormat.test_coef_fmt[all_stats-typst]
   '''
   #table(
     columns: (auto, 1fr), align: (left, center),
@@ -158,7 +158,7 @@
   )
   '''
 # ---
-# name: TestETableCoefFormat.test_coef_fmt_default_html
+# name: TestETableCoefFormat.test_coef_fmt[default-html]
   '''
   <div id="STABLE_ID" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
   <style>
@@ -259,7 +259,7 @@
           
   '''
 # ---
-# name: TestETableCoefFormat.test_coef_fmt_default_latex
+# name: TestETableCoefFormat.test_coef_fmt[default-latex]
   '''
   \begin{threeparttable}
   \begingroup
@@ -294,7 +294,7 @@
   \end{threeparttable}
   '''
 # ---
-# name: TestETableCoefFormat.test_coef_fmt_default_typst
+# name: TestETableCoefFormat.test_coef_fmt[default-typst]
   '''
   #table(
     columns: (auto, 1fr), align: (left, center),
@@ -317,7 +317,7 @@
   )
   '''
 # ---
-# name: TestETableCoefFormat.test_coef_fmt_different_decimals_html
+# name: TestETableCoefFormat.test_coef_fmt[different_decimals-html]
   '''
   <div id="STABLE_ID" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
   <style>
@@ -418,7 +418,7 @@
           
   '''
 # ---
-# name: TestETableCoefFormat.test_coef_fmt_different_decimals_latex
+# name: TestETableCoefFormat.test_coef_fmt[different_decimals-latex]
   '''
   \begin{threeparttable}
   \begingroup
@@ -453,7 +453,7 @@
   \end{threeparttable}
   '''
 # ---
-# name: TestETableCoefFormat.test_coef_fmt_different_decimals_typst
+# name: TestETableCoefFormat.test_coef_fmt[different_decimals-typst]
   '''
   #table(
     columns: (auto, 1fr), align: (left, center),
@@ -476,7 +476,7 @@
   )
   '''
 # ---
-# name: TestETableCoefFormat.test_coef_fmt_with_pvalue_html
+# name: TestETableCoefFormat.test_coef_fmt[with_pvalue-html]
   '''
   <div id="STABLE_ID" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
   <style>
@@ -577,7 +577,7 @@
           
   '''
 # ---
-# name: TestETableCoefFormat.test_coef_fmt_with_pvalue_latex
+# name: TestETableCoefFormat.test_coef_fmt[with_pvalue-latex]
   '''
   \begin{threeparttable}
   \begingroup
@@ -612,7 +612,7 @@
   \end{threeparttable}
   '''
 # ---
-# name: TestETableCoefFormat.test_coef_fmt_with_pvalue_typst
+# name: TestETableCoefFormat.test_coef_fmt[with_pvalue-typst]
   '''
   #table(
     columns: (auto, 1fr), align: (left, center),
@@ -635,7 +635,7 @@
   )
   '''
 # ---
-# name: TestETableCoefFormat.test_coef_fmt_with_tstat_html
+# name: TestETableCoefFormat.test_coef_fmt[with_tstat-html]
   '''
   <div id="STABLE_ID" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
   <style>
@@ -736,7 +736,7 @@
           
   '''
 # ---
-# name: TestETableCoefFormat.test_coef_fmt_with_tstat_latex
+# name: TestETableCoefFormat.test_coef_fmt[with_tstat-latex]
   '''
   \begin{threeparttable}
   \begingroup
@@ -771,7 +771,7 @@
   \end{threeparttable}
   '''
 # ---
-# name: TestETableCoefFormat.test_coef_fmt_with_tstat_typst
+# name: TestETableCoefFormat.test_coef_fmt[with_tstat-typst]
   '''
   #table(
     columns: (auto, 1fr), align: (left, center),

--- a/tests/api/__snapshots__/test_formatting.ambr
+++ b/tests/api/__snapshots__/test_formatting.ambr
@@ -135,6 +135,29 @@
   \end{threeparttable}
   '''
 # ---
+# name: TestETableCoefFormat.test_coef_fmt_all_stats_typst
+  '''
+  #table(
+    columns: (auto, 1fr), align: (left, center),
+    column-gutter: (0em),
+    stroke: none, row-gutter: 0.2em,
+    table.hline(stroke: 0.08em),
+    [], [#table.cell(colspan: 1)[y]],
+    table.hline(stroke: 0.03em, start: 1, end: 2),
+    [], [(1)],
+    table.hline(stroke: 0.05em),
+    table.hline(stroke: 0.03em),
+    [x], [2.000 \ (0.000) \ \[16501042479138636.00\]],
+    [Intercept], [0.100 \ (0.000) \ \[248762575240997.72\]],
+    table.hline(stroke: 0.03em),
+    table.hline(stroke: 0.03em),
+    [Observations], [100],
+    [$R^2$], [1],
+    table.hline(stroke: 0.08em),
+    [#table.cell(colspan: 2)[#text(size: 10pt)[Format of coefficient cell: Coefficient   (Std. Error)   \[t-stats\]]]],
+  )
+  '''
+# ---
 # name: TestETableCoefFormat.test_coef_fmt_default_html
   '''
   <div id="STABLE_ID" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
@@ -269,6 +292,29 @@
   Significance levels: * p < 0.1, ** p < 0.05, *** p < 0.01. Format of coefficient cell: Coefficient   (Std. Error)\end{minipage}
   
   \end{threeparttable}
+  '''
+# ---
+# name: TestETableCoefFormat.test_coef_fmt_default_typst
+  '''
+  #table(
+    columns: (auto, 1fr), align: (left, center),
+    column-gutter: (0em),
+    stroke: none, row-gutter: 0.2em,
+    table.hline(stroke: 0.08em),
+    [], [#table.cell(colspan: 1)[y]],
+    table.hline(stroke: 0.03em, start: 1, end: 2),
+    [], [(1)],
+    table.hline(stroke: 0.05em),
+    table.hline(stroke: 0.03em),
+    [x], [2.000\*\*\* \ (0.000)],
+    [Intercept], [0.100\*\*\* \ (0.000)],
+    table.hline(stroke: 0.03em),
+    table.hline(stroke: 0.03em),
+    [Observations], [100],
+    [$R^2$], [1],
+    table.hline(stroke: 0.08em),
+    [#table.cell(colspan: 2)[#text(size: 10pt)[Significance levels: \* p \< 0.1, \*\* p \< 0.05, \*\*\* p \< 0.01. Format of coefficient cell: Coefficient   (Std. Error)]]],
+  )
   '''
 # ---
 # name: TestETableCoefFormat.test_coef_fmt_different_decimals_html
@@ -407,6 +453,29 @@
   \end{threeparttable}
   '''
 # ---
+# name: TestETableCoefFormat.test_coef_fmt_different_decimals_typst
+  '''
+  #table(
+    columns: (auto, 1fr), align: (left, center),
+    column-gutter: (0em),
+    stroke: none, row-gutter: 0.2em,
+    table.hline(stroke: 0.08em),
+    [], [#table.cell(colspan: 1)[y]],
+    table.hline(stroke: 0.03em, start: 1, end: 2),
+    [], [(1)],
+    table.hline(stroke: 0.05em),
+    table.hline(stroke: 0.03em),
+    [x], [2.0000 \ (0.00)],
+    [Intercept], [0.1000 \ (0.00)],
+    table.hline(stroke: 0.03em),
+    table.hline(stroke: 0.03em),
+    [Observations], [100],
+    [$R^2$], [1],
+    table.hline(stroke: 0.08em),
+    [#table.cell(colspan: 2)[#text(size: 10pt)[Format of coefficient cell: Coefficient   (Std. Error)]]],
+  )
+  '''
+# ---
 # name: TestETableCoefFormat.test_coef_fmt_with_pvalue_html
   '''
   <div id="STABLE_ID" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
@@ -543,6 +612,29 @@
   \end{threeparttable}
   '''
 # ---
+# name: TestETableCoefFormat.test_coef_fmt_with_pvalue_typst
+  '''
+  #table(
+    columns: (auto, 1fr), align: (left, center),
+    column-gutter: (0em),
+    stroke: none, row-gutter: 0.2em,
+    table.hline(stroke: 0.08em),
+    [], [#table.cell(colspan: 1)[y]],
+    table.hline(stroke: 0.03em, start: 1, end: 2),
+    [], [(1)],
+    table.hline(stroke: 0.05em),
+    table.hline(stroke: 0.03em),
+    [x], [2.000 \ (0.0000)],
+    [Intercept], [0.100 \ (0.0000)],
+    table.hline(stroke: 0.03em),
+    table.hline(stroke: 0.03em),
+    [Observations], [100],
+    [$R^2$], [1],
+    table.hline(stroke: 0.08em),
+    [#table.cell(colspan: 2)[#text(size: 10pt)[Format of coefficient cell: Coefficient   (p-value)]]],
+  )
+  '''
+# ---
 # name: TestETableCoefFormat.test_coef_fmt_with_tstat_html
   '''
   <div id="STABLE_ID" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
@@ -677,5 +769,28 @@
   Format of coefficient cell: Coefficient   [t-stats]\end{minipage}
   
   \end{threeparttable}
+  '''
+# ---
+# name: TestETableCoefFormat.test_coef_fmt_with_tstat_typst
+  '''
+  #table(
+    columns: (auto, 1fr), align: (left, center),
+    column-gutter: (0em),
+    stroke: none, row-gutter: 0.2em,
+    table.hline(stroke: 0.08em),
+    [], [#table.cell(colspan: 1)[y]],
+    table.hline(stroke: 0.03em, start: 1, end: 2),
+    [], [(1)],
+    table.hline(stroke: 0.05em),
+    table.hline(stroke: 0.03em),
+    [x], [2.000 \ \[16501042479138636.00\]],
+    [Intercept], [0.100 \ \[248762575240997.72\]],
+    table.hline(stroke: 0.03em),
+    table.hline(stroke: 0.03em),
+    [Observations], [100],
+    [$R^2$], [1],
+    table.hline(stroke: 0.08em),
+    [#table.cell(colspan: 2)[#text(size: 10pt)[Format of coefficient cell: Coefficient   \[t-stats\]]]],
+  )
   '''
 # ---

--- a/tests/api/__snapshots__/test_formatting.ambr
+++ b/tests/api/__snapshots__/test_formatting.ambr
@@ -68,11 +68,11 @@
     </tr>
     <tr>
       <th class="gt_row gt_left gt_stub">x</th>
-      <td class="gt_row gt_center">2.000 <br> (0.000) <br> [inf]</td>
+      <td class="gt_row gt_center">2.000 <br> (0.000) <br> [16501042479138636.00]</td>
     </tr>
     <tr>
       <th class="gt_row gt_left gt_stub">Intercept</th>
-      <td class="gt_row gt_center">0.100 <br> (0.000) <br> [inf]</td>
+      <td class="gt_row gt_center">0.100 <br> (0.000) <br> [248762575240997.72]</td>
     </tr>
     <tr class="gt_group_heading_row">
       <th class="gt_group_heading" colspan="2">stats</th>
@@ -114,10 +114,10 @@
    & (1) \\
   \midrule
   \addlinespace[1ex]
-  x & \makecell{2.000 \\ (0.000) \\ [inf]} \\
+  x & \makecell{2.000 \\ (0.000) \\ [16501042479138636.00]} \\
   \addlinespace[0.5ex]
   \addlinespace[0.5ex]
-  Intercept & \makecell{0.100 \\ (0.000) \\ [inf]} \\
+  Intercept & \makecell{0.100 \\ (0.000) \\ [248762575240997.72]} \\
   \addlinespace[0.5ex]
   \midrule
   \addlinespace[1ex]
@@ -612,11 +612,11 @@
     </tr>
     <tr>
       <th class="gt_row gt_left gt_stub">x</th>
-      <td class="gt_row gt_center">2.000 <br> [inf]</td>
+      <td class="gt_row gt_center">2.000 <br> [16501042479138636.00]</td>
     </tr>
     <tr>
       <th class="gt_row gt_left gt_stub">Intercept</th>
-      <td class="gt_row gt_center">0.100 <br> [inf]</td>
+      <td class="gt_row gt_center">0.100 <br> [248762575240997.72]</td>
     </tr>
     <tr class="gt_group_heading_row">
       <th class="gt_group_heading" colspan="2">stats</th>
@@ -658,10 +658,10 @@
    & (1) \\
   \midrule
   \addlinespace[1ex]
-  x & \makecell{2.000 \\ [inf]} \\
+  x & \makecell{2.000 \\ [16501042479138636.00]} \\
   \addlinespace[0.5ex]
   \addlinespace[0.5ex]
-  Intercept & \makecell{0.100 \\ [inf]} \\
+  Intercept & \makecell{0.100 \\ [248762575240997.72]} \\
   \addlinespace[0.5ex]
   \midrule
   \addlinespace[1ex]

--- a/tests/api/__snapshots__/test_formatting.ambr
+++ b/tests/api/__snapshots__/test_formatting.ambr
@@ -8,7 +8,7 @@
             -webkit-font-smoothing: antialiased;
             -moz-osx-font-smoothing: grayscale;
           }
-  
+
   #STABLE_ID thead, tbody, tfoot, tr, td, th { border-style: none; }
    tr { background-color: transparent; }
   #STABLE_ID p { margin: 0; padding: 0; }
@@ -47,11 +47,11 @@
    #STABLE_ID .gt_super { font-size: 65%; }
    #STABLE_ID .gt_footnote_marks { font-size: 75%; vertical-align: 0.4em; position: initial; }
    #STABLE_ID .gt_asterisk { font-size: 100%; vertical-align: 0; }
-   
+
   </style>
   <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>
-  
+
   <tr class="gt_col_headings gt_spanner_row">
     <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="2" colspan="1" scope="col" id=""></th>
     <th class="gt_center gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="1" scope="col" id="y">
@@ -87,17 +87,17 @@
     </tr>
   </tbody>
     <tfoot class="gt_sourcenotes">
-    
+
     <tr>
       <td class="gt_sourcenote" colspan="2">Format of coefficient cell: Coefficient   (Std. Error)   [t-stats]</td>
     </tr>
-  
+
   </tfoot>
-  
+
   </table>
-  
+
   </div>
-          
+
   '''
 # ---
 # name: TestETableCoefFormat.test_coef_fmt[all_stats-latex]
@@ -131,7 +131,7 @@
   \endgroup
   \noindent\begin{minipage}{\linewidth}\smallskip\footnotesize
   Format of coefficient cell: Coefficient   (Std. Error)   [t-stats]\end{minipage}
-  
+
   \end{threeparttable}
   '''
 # ---
@@ -167,7 +167,7 @@
             -webkit-font-smoothing: antialiased;
             -moz-osx-font-smoothing: grayscale;
           }
-  
+
   #STABLE_ID thead, tbody, tfoot, tr, td, th { border-style: none; }
    tr { background-color: transparent; }
   #STABLE_ID p { margin: 0; padding: 0; }
@@ -206,11 +206,11 @@
    #STABLE_ID .gt_super { font-size: 65%; }
    #STABLE_ID .gt_footnote_marks { font-size: 75%; vertical-align: 0.4em; position: initial; }
    #STABLE_ID .gt_asterisk { font-size: 100%; vertical-align: 0; }
-   
+
   </style>
   <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>
-  
+
   <tr class="gt_col_headings gt_spanner_row">
     <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="2" colspan="1" scope="col" id=""></th>
     <th class="gt_center gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="1" scope="col" id="y">
@@ -246,17 +246,17 @@
     </tr>
   </tbody>
     <tfoot class="gt_sourcenotes">
-    
+
     <tr>
       <td class="gt_sourcenote" colspan="2">Significance levels: * p &lt; 0.1, ** p &lt; 0.05, *** p &lt; 0.01. Format of coefficient cell: Coefficient   (Std. Error)</td>
     </tr>
-  
+
   </tfoot>
-  
+
   </table>
-  
+
   </div>
-          
+
   '''
 # ---
 # name: TestETableCoefFormat.test_coef_fmt[default-latex]
@@ -290,7 +290,7 @@
   \endgroup
   \noindent\begin{minipage}{\linewidth}\smallskip\footnotesize
   Significance levels: * p < 0.1, ** p < 0.05, *** p < 0.01. Format of coefficient cell: Coefficient   (Std. Error)\end{minipage}
-  
+
   \end{threeparttable}
   '''
 # ---
@@ -326,7 +326,7 @@
             -webkit-font-smoothing: antialiased;
             -moz-osx-font-smoothing: grayscale;
           }
-  
+
   #STABLE_ID thead, tbody, tfoot, tr, td, th { border-style: none; }
    tr { background-color: transparent; }
   #STABLE_ID p { margin: 0; padding: 0; }
@@ -365,11 +365,11 @@
    #STABLE_ID .gt_super { font-size: 65%; }
    #STABLE_ID .gt_footnote_marks { font-size: 75%; vertical-align: 0.4em; position: initial; }
    #STABLE_ID .gt_asterisk { font-size: 100%; vertical-align: 0; }
-   
+
   </style>
   <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>
-  
+
   <tr class="gt_col_headings gt_spanner_row">
     <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="2" colspan="1" scope="col" id=""></th>
     <th class="gt_center gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="1" scope="col" id="y">
@@ -405,17 +405,17 @@
     </tr>
   </tbody>
     <tfoot class="gt_sourcenotes">
-    
+
     <tr>
       <td class="gt_sourcenote" colspan="2">Format of coefficient cell: Coefficient   (Std. Error)</td>
     </tr>
-  
+
   </tfoot>
-  
+
   </table>
-  
+
   </div>
-          
+
   '''
 # ---
 # name: TestETableCoefFormat.test_coef_fmt[different_decimals-latex]
@@ -449,7 +449,7 @@
   \endgroup
   \noindent\begin{minipage}{\linewidth}\smallskip\footnotesize
   Format of coefficient cell: Coefficient   (Std. Error)\end{minipage}
-  
+
   \end{threeparttable}
   '''
 # ---
@@ -485,7 +485,7 @@
             -webkit-font-smoothing: antialiased;
             -moz-osx-font-smoothing: grayscale;
           }
-  
+
   #STABLE_ID thead, tbody, tfoot, tr, td, th { border-style: none; }
    tr { background-color: transparent; }
   #STABLE_ID p { margin: 0; padding: 0; }
@@ -524,11 +524,11 @@
    #STABLE_ID .gt_super { font-size: 65%; }
    #STABLE_ID .gt_footnote_marks { font-size: 75%; vertical-align: 0.4em; position: initial; }
    #STABLE_ID .gt_asterisk { font-size: 100%; vertical-align: 0; }
-   
+
   </style>
   <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>
-  
+
   <tr class="gt_col_headings gt_spanner_row">
     <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="2" colspan="1" scope="col" id=""></th>
     <th class="gt_center gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="1" scope="col" id="y">
@@ -564,17 +564,17 @@
     </tr>
   </tbody>
     <tfoot class="gt_sourcenotes">
-    
+
     <tr>
       <td class="gt_sourcenote" colspan="2">Format of coefficient cell: Coefficient   (p-value)</td>
     </tr>
-  
+
   </tfoot>
-  
+
   </table>
-  
+
   </div>
-          
+
   '''
 # ---
 # name: TestETableCoefFormat.test_coef_fmt[with_pvalue-latex]
@@ -608,7 +608,7 @@
   \endgroup
   \noindent\begin{minipage}{\linewidth}\smallskip\footnotesize
   Format of coefficient cell: Coefficient   (p-value)\end{minipage}
-  
+
   \end{threeparttable}
   '''
 # ---
@@ -644,7 +644,7 @@
             -webkit-font-smoothing: antialiased;
             -moz-osx-font-smoothing: grayscale;
           }
-  
+
   #STABLE_ID thead, tbody, tfoot, tr, td, th { border-style: none; }
    tr { background-color: transparent; }
   #STABLE_ID p { margin: 0; padding: 0; }
@@ -683,11 +683,11 @@
    #STABLE_ID .gt_super { font-size: 65%; }
    #STABLE_ID .gt_footnote_marks { font-size: 75%; vertical-align: 0.4em; position: initial; }
    #STABLE_ID .gt_asterisk { font-size: 100%; vertical-align: 0; }
-   
+
   </style>
   <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>
-  
+
   <tr class="gt_col_headings gt_spanner_row">
     <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="2" colspan="1" scope="col" id=""></th>
     <th class="gt_center gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="1" scope="col" id="y">
@@ -723,17 +723,17 @@
     </tr>
   </tbody>
     <tfoot class="gt_sourcenotes">
-    
+
     <tr>
       <td class="gt_sourcenote" colspan="2">Format of coefficient cell: Coefficient   [t-stats]</td>
     </tr>
-  
+
   </tfoot>
-  
+
   </table>
-  
+
   </div>
-          
+
   '''
 # ---
 # name: TestETableCoefFormat.test_coef_fmt[with_tstat-latex]
@@ -767,7 +767,7 @@
   \endgroup
   \noindent\begin{minipage}{\linewidth}\smallskip\footnotesize
   Format of coefficient cell: Coefficient   [t-stats]\end{minipage}
-  
+
   \end{threeparttable}
   '''
 # ---

--- a/tests/api/__snapshots__/test_selection.ambr
+++ b/tests/api/__snapshots__/test_selection.ambr
@@ -128,6 +128,28 @@
   \end{threeparttable}
   '''
 # ---
+# name: TestETableCoefSelection.test_drop_intercept_typst
+  '''
+  #table(
+    columns: (auto, 1fr), align: (left, center),
+    column-gutter: (0em),
+    stroke: none, row-gutter: 0.2em,
+    table.hline(stroke: 0.08em),
+    [], [#table.cell(colspan: 1)[y]],
+    table.hline(stroke: 0.03em, start: 1, end: 2),
+    [], [(1)],
+    table.hline(stroke: 0.05em),
+    table.hline(stroke: 0.03em),
+    [x], [2.000\*\*\* \ (0.000)],
+    table.hline(stroke: 0.03em),
+    table.hline(stroke: 0.03em),
+    [Observations], [100],
+    [$R^2$], [1],
+    table.hline(stroke: 0.08em),
+    [#table.cell(colspan: 2)[#text(size: 10pt)[Significance levels: \* p \< 0.1, \*\* p \< 0.05, \*\*\* p \< 0.01. Format of coefficient cell: Coefficient   (Std. Error)]]],
+  )
+  '''
+# ---
 # name: TestETableCoefSelection.test_exact_match_html
   '''
   <div id="STABLE_ID" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
@@ -259,6 +281,50 @@
   Significance levels: * p < 0.1, ** p < 0.05, *** p < 0.01. Format of coefficient cell: Coefficient   (Std. Error)\end{minipage}
   
   \end{threeparttable}
+  '''
+# ---
+# name: TestETableCoefSelection.test_exact_match_typst
+  '''
+  #table(
+    columns: (auto, 1fr, 1fr), align: (left, center, center),
+    column-gutter: (0em, 0em),
+    stroke: none, row-gutter: 0.2em,
+    table.hline(stroke: 0.08em),
+    [], [#table.cell(colspan: 2)[y]],
+    table.hline(stroke: 0.03em, start: 1, end: 3),
+    [], [(1)], [(2)],
+    table.hline(stroke: 0.05em),
+    table.hline(stroke: 0.03em),
+    [x], [2.100\*\*\* \ (0.000)], [2.100\*\*\* \ (0.000)],
+    table.hline(stroke: 0.03em),
+    table.hline(stroke: 0.03em),
+    [Observations], [100], [100],
+    [$R^2$], [1], [1],
+    table.hline(stroke: 0.08em),
+    [#table.cell(colspan: 3)[#text(size: 10pt)[Significance levels: \* p \< 0.1, \*\* p \< 0.05, \*\*\* p \< 0.01. Format of coefficient cell: Coefficient   (Std. Error)]]],
+  )
+  '''
+# ---
+# name: TestETableCoefSelection.test_keep_multiple_coefs_typst
+  '''
+  #table(
+    columns: (auto, 1fr, 1fr), align: (left, center, center),
+    column-gutter: (0em, 0em),
+    stroke: none, row-gutter: 0.2em,
+    table.hline(stroke: 0.08em),
+    [], [#table.cell(colspan: 2)[y]],
+    table.hline(stroke: 0.03em, start: 1, end: 3),
+    [], [(1)], [(2)],
+    table.hline(stroke: 0.05em),
+    table.hline(stroke: 0.03em),
+    [x], [2.100\*\*\* \ (0.000)], [2.100\*\*\* \ (0.000)],
+    table.hline(stroke: 0.03em),
+    table.hline(stroke: 0.03em),
+    [Observations], [100], [100],
+    [$R^2$], [1], [1],
+    table.hline(stroke: 0.08em),
+    [#table.cell(colspan: 3)[#text(size: 10pt)[Significance levels: \* p \< 0.1, \*\* p \< 0.05, \*\*\* p \< 0.01. Format of coefficient cell: Coefficient   (Std. Error)]]],
+  )
   '''
 # ---
 # name: TestETableCoefSelection.test_keep_reorders_html
@@ -408,6 +474,30 @@
   Significance levels: * p < 0.1, ** p < 0.05, *** p < 0.01. Format of coefficient cell: Coefficient   (Std. Error)\end{minipage}
   
   \end{threeparttable}
+  '''
+# ---
+# name: TestETableCoefSelection.test_keep_reorders_typst
+  '''
+  #table(
+    columns: (auto, 1fr, 1fr), align: (left, center, center),
+    column-gutter: (0em, 0em),
+    stroke: none, row-gutter: 0.2em,
+    table.hline(stroke: 0.08em),
+    [], [#table.cell(colspan: 2)[y]],
+    table.hline(stroke: 0.03em, start: 1, end: 3),
+    [], [(1)], [(2)],
+    table.hline(stroke: 0.05em),
+    table.hline(stroke: 0.03em),
+    [group=B], [], [-0.000 \ (0.000)],
+    [x], [2.100\*\*\* \ (0.000)], [2.100\*\*\* \ (0.000)],
+    [Intercept], [0.000 \ (0.000)], [0.000 \ (0.000)],
+    table.hline(stroke: 0.03em),
+    table.hline(stroke: 0.03em),
+    [Observations], [100], [100],
+    [$R^2$], [1], [1],
+    table.hline(stroke: 0.08em),
+    [#table.cell(colspan: 3)[#text(size: 10pt)[Significance levels: \* p \< 0.1, \*\* p \< 0.05, \*\*\* p \< 0.01. Format of coefficient cell: Coefficient   (Std. Error)]]],
+  )
   '''
 # ---
 # name: TestETableCoefSelection.test_keep_single_coef_html
@@ -682,5 +772,28 @@
   Significance levels: * p < 0.1, ** p < 0.05, *** p < 0.01. Format of coefficient cell: Coefficient   (Std. Error)\end{minipage}
   
   \end{threeparttable}
+  '''
+# ---
+# name: TestETableCoefSelection.test_keep_with_regex_typst
+  '''
+  #table(
+    columns: (auto, 1fr, 1fr), align: (left, center, center),
+    column-gutter: (0em, 0em),
+    stroke: none, row-gutter: 0.2em,
+    table.hline(stroke: 0.08em),
+    [], [#table.cell(colspan: 2)[y]],
+    table.hline(stroke: 0.03em, start: 1, end: 3),
+    [], [(1)], [(2)],
+    table.hline(stroke: 0.05em),
+    table.hline(stroke: 0.03em),
+    [x], [2.100\*\*\* \ (0.000)], [2.100\*\*\* \ (0.000)],
+    [group=B], [], [-0.000 \ (0.000)],
+    table.hline(stroke: 0.03em),
+    table.hline(stroke: 0.03em),
+    [Observations], [100], [100],
+    [$R^2$], [1], [1],
+    table.hline(stroke: 0.08em),
+    [#table.cell(colspan: 3)[#text(size: 10pt)[Significance levels: \* p \< 0.1, \*\* p \< 0.05, \*\*\* p \< 0.01. Format of coefficient cell: Coefficient   (Std. Error)]]],
+  )
   '''
 # ---

--- a/tests/api/__snapshots__/test_selection.ambr
+++ b/tests/api/__snapshots__/test_selection.ambr
@@ -332,7 +332,7 @@
     <tr>
       <th class="gt_row gt_left gt_stub">group=B</th>
       <td class="gt_row gt_center"></td>
-      <td class="gt_row gt_center">-0.000*** <br> (0.000)</td>
+      <td class="gt_row gt_center">-0.000 <br> (0.000)</td>
     </tr>
     <tr>
       <th class="gt_row gt_left gt_stub">x</th>
@@ -341,8 +341,8 @@
     </tr>
     <tr>
       <th class="gt_row gt_left gt_stub">Intercept</th>
-      <td class="gt_row gt_center">0.000** <br> (0.000)</td>
-      <td class="gt_row gt_center">0.000*** <br> (0.000)</td>
+      <td class="gt_row gt_center">0.000 <br> (0.000)</td>
+      <td class="gt_row gt_center">0.000 <br> (0.000)</td>
     </tr>
     <tr class="gt_group_heading_row">
       <th class="gt_group_heading" colspan="3">stats</th>
@@ -386,13 +386,13 @@
    & (1) & (2) \\
   \midrule
   \addlinespace[1ex]
-  group=B &  & \makecell{-0.000*** \\ (0.000)} \\
+  group=B &  & \makecell{-0.000 \\ (0.000)} \\
   \addlinespace[0.5ex]
   \addlinespace[0.5ex]
   x & \makecell{2.100*** \\ (0.000)} & \makecell{2.100*** \\ (0.000)} \\
   \addlinespace[0.5ex]
   \addlinespace[0.5ex]
-  Intercept & \makecell{0.000** \\ (0.000)} & \makecell{0.000*** \\ (0.000)} \\
+  Intercept & \makecell{0.000 \\ (0.000)} & \makecell{0.000 \\ (0.000)} \\
   \addlinespace[0.5ex]
   \midrule
   \addlinespace[1ex]
@@ -619,7 +619,7 @@
     <tr>
       <th class="gt_row gt_left gt_stub">group=B</th>
       <td class="gt_row gt_center"></td>
-      <td class="gt_row gt_center">-0.000*** <br> (0.000)</td>
+      <td class="gt_row gt_center">-0.000 <br> (0.000)</td>
     </tr>
     <tr class="gt_group_heading_row">
       <th class="gt_group_heading" colspan="3">stats</th>
@@ -666,7 +666,7 @@
   x & \makecell{2.100*** \\ (0.000)} & \makecell{2.100*** \\ (0.000)} \\
   \addlinespace[0.5ex]
   \addlinespace[0.5ex]
-  group=B &  & \makecell{-0.000*** \\ (0.000)} \\
+  group=B &  & \makecell{-0.000 \\ (0.000)} \\
   \addlinespace[0.5ex]
   \midrule
   \addlinespace[1ex]

--- a/tests/api/__snapshots__/test_selection.ambr
+++ b/tests/api/__snapshots__/test_selection.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: TestETableCoefSelection.test_drop_intercept_html
+# name: TestETableCoefSelection.test_coef_selection[drop_intercept-html]
   '''
   <div id="STABLE_ID" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
   <style>
@@ -96,7 +96,7 @@
           
   '''
 # ---
-# name: TestETableCoefSelection.test_drop_intercept_latex
+# name: TestETableCoefSelection.test_coef_selection[drop_intercept-latex]
   '''
   \begin{threeparttable}
   \begingroup
@@ -128,7 +128,7 @@
   \end{threeparttable}
   '''
 # ---
-# name: TestETableCoefSelection.test_drop_intercept_typst
+# name: TestETableCoefSelection.test_coef_selection[drop_intercept-typst]
   '''
   #table(
     columns: (auto, 1fr), align: (left, center),
@@ -150,7 +150,7 @@
   )
   '''
 # ---
-# name: TestETableCoefSelection.test_exact_match_html
+# name: TestETableCoefSelection.test_coef_selection[exact_match-html]
   '''
   <div id="STABLE_ID" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
   <style>
@@ -251,7 +251,7 @@
           
   '''
 # ---
-# name: TestETableCoefSelection.test_exact_match_latex
+# name: TestETableCoefSelection.test_coef_selection[exact_match-latex]
   '''
   \begin{threeparttable}
   \begingroup
@@ -283,7 +283,7 @@
   \end{threeparttable}
   '''
 # ---
-# name: TestETableCoefSelection.test_exact_match_typst
+# name: TestETableCoefSelection.test_coef_selection[exact_match-typst]
   '''
   #table(
     columns: (auto, 1fr, 1fr), align: (left, center, center),
@@ -305,29 +305,7 @@
   )
   '''
 # ---
-# name: TestETableCoefSelection.test_keep_multiple_coefs_typst
-  '''
-  #table(
-    columns: (auto, 1fr, 1fr), align: (left, center, center),
-    column-gutter: (0em, 0em),
-    stroke: none, row-gutter: 0.2em,
-    table.hline(stroke: 0.08em),
-    [], [#table.cell(colspan: 2)[y]],
-    table.hline(stroke: 0.03em, start: 1, end: 3),
-    [], [(1)], [(2)],
-    table.hline(stroke: 0.05em),
-    table.hline(stroke: 0.03em),
-    [x], [2.100\*\*\* \ (0.000)], [2.100\*\*\* \ (0.000)],
-    table.hline(stroke: 0.03em),
-    table.hline(stroke: 0.03em),
-    [Observations], [100], [100],
-    [$R^2$], [1], [1],
-    table.hline(stroke: 0.08em),
-    [#table.cell(colspan: 3)[#text(size: 10pt)[Significance levels: \* p \< 0.1, \*\* p \< 0.05, \*\*\* p \< 0.01. Format of coefficient cell: Coefficient   (Std. Error)]]],
-  )
-  '''
-# ---
-# name: TestETableCoefSelection.test_keep_reorders_html
+# name: TestETableCoefSelection.test_coef_selection[keep_reorders-html]
   '''
   <div id="STABLE_ID" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
   <style>
@@ -438,7 +416,7 @@
           
   '''
 # ---
-# name: TestETableCoefSelection.test_keep_reorders_latex
+# name: TestETableCoefSelection.test_coef_selection[keep_reorders-latex]
   '''
   \begin{threeparttable}
   \begingroup
@@ -476,7 +454,7 @@
   \end{threeparttable}
   '''
 # ---
-# name: TestETableCoefSelection.test_keep_reorders_typst
+# name: TestETableCoefSelection.test_coef_selection[keep_reorders-typst]
   '''
   #table(
     columns: (auto, 1fr, 1fr), align: (left, center, center),
@@ -500,7 +478,7 @@
   )
   '''
 # ---
-# name: TestETableCoefSelection.test_keep_single_coef_html
+# name: TestETableCoefSelection.test_coef_selection[keep_single_coef-html]
   '''
   <div id="STABLE_ID" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
   <style>
@@ -601,7 +579,7 @@
           
   '''
 # ---
-# name: TestETableCoefSelection.test_keep_single_coef_latex
+# name: TestETableCoefSelection.test_coef_selection[keep_single_coef-latex]
   '''
   \begin{threeparttable}
   \begingroup
@@ -633,7 +611,29 @@
   \end{threeparttable}
   '''
 # ---
-# name: TestETableCoefSelection.test_keep_with_regex_html
+# name: TestETableCoefSelection.test_coef_selection[keep_single_coef-typst]
+  '''
+  #table(
+    columns: (auto, 1fr, 1fr), align: (left, center, center),
+    column-gutter: (0em, 0em),
+    stroke: none, row-gutter: 0.2em,
+    table.hline(stroke: 0.08em),
+    [], [#table.cell(colspan: 2)[y]],
+    table.hline(stroke: 0.03em, start: 1, end: 3),
+    [], [(1)], [(2)],
+    table.hline(stroke: 0.05em),
+    table.hline(stroke: 0.03em),
+    [x], [2.100\*\*\* \ (0.000)], [2.100\*\*\* \ (0.000)],
+    table.hline(stroke: 0.03em),
+    table.hline(stroke: 0.03em),
+    [Observations], [100], [100],
+    [$R^2$], [1], [1],
+    table.hline(stroke: 0.08em),
+    [#table.cell(colspan: 3)[#text(size: 10pt)[Significance levels: \* p \< 0.1, \*\* p \< 0.05, \*\*\* p \< 0.01. Format of coefficient cell: Coefficient   (Std. Error)]]],
+  )
+  '''
+# ---
+# name: TestETableCoefSelection.test_coef_selection[keep_with_regex-html]
   '''
   <div id="STABLE_ID" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
   <style>
@@ -739,7 +739,7 @@
           
   '''
 # ---
-# name: TestETableCoefSelection.test_keep_with_regex_latex
+# name: TestETableCoefSelection.test_coef_selection[keep_with_regex-latex]
   '''
   \begin{threeparttable}
   \begingroup
@@ -774,7 +774,7 @@
   \end{threeparttable}
   '''
 # ---
-# name: TestETableCoefSelection.test_keep_with_regex_typst
+# name: TestETableCoefSelection.test_coef_selection[keep_with_regex-typst]
   '''
   #table(
     columns: (auto, 1fr, 1fr), align: (left, center, center),

--- a/tests/api/__snapshots__/test_selection.ambr
+++ b/tests/api/__snapshots__/test_selection.ambr
@@ -8,7 +8,7 @@
             -webkit-font-smoothing: antialiased;
             -moz-osx-font-smoothing: grayscale;
           }
-  
+
   #STABLE_ID thead, tbody, tfoot, tr, td, th { border-style: none; }
    tr { background-color: transparent; }
   #STABLE_ID p { margin: 0; padding: 0; }
@@ -47,11 +47,11 @@
    #STABLE_ID .gt_super { font-size: 65%; }
    #STABLE_ID .gt_footnote_marks { font-size: 75%; vertical-align: 0.4em; position: initial; }
    #STABLE_ID .gt_asterisk { font-size: 100%; vertical-align: 0; }
-   
+
   </style>
   <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>
-  
+
   <tr class="gt_col_headings gt_spanner_row">
     <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="2" colspan="1" scope="col" id=""></th>
     <th class="gt_center gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="1" scope="col" id="y">
@@ -83,17 +83,17 @@
     </tr>
   </tbody>
     <tfoot class="gt_sourcenotes">
-    
+
     <tr>
       <td class="gt_sourcenote" colspan="2">Significance levels: * p &lt; 0.1, ** p &lt; 0.05, *** p &lt; 0.01. Format of coefficient cell: Coefficient   (Std. Error)</td>
     </tr>
-  
+
   </tfoot>
-  
+
   </table>
-  
+
   </div>
-          
+
   '''
 # ---
 # name: TestETableCoefSelection.test_coef_selection[drop_intercept-latex]
@@ -124,7 +124,7 @@
   \endgroup
   \noindent\begin{minipage}{\linewidth}\smallskip\footnotesize
   Significance levels: * p < 0.1, ** p < 0.05, *** p < 0.01. Format of coefficient cell: Coefficient   (Std. Error)\end{minipage}
-  
+
   \end{threeparttable}
   '''
 # ---
@@ -159,7 +159,7 @@
             -webkit-font-smoothing: antialiased;
             -moz-osx-font-smoothing: grayscale;
           }
-  
+
   #STABLE_ID thead, tbody, tfoot, tr, td, th { border-style: none; }
    tr { background-color: transparent; }
   #STABLE_ID p { margin: 0; padding: 0; }
@@ -198,11 +198,11 @@
    #STABLE_ID .gt_super { font-size: 65%; }
    #STABLE_ID .gt_footnote_marks { font-size: 75%; vertical-align: 0.4em; position: initial; }
    #STABLE_ID .gt_asterisk { font-size: 100%; vertical-align: 0; }
-   
+
   </style>
   <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>
-  
+
   <tr class="gt_col_headings gt_spanner_row">
     <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="2" colspan="1" scope="col" id=""></th>
     <th class="gt_center gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="2" scope="colgroup" id="y">
@@ -238,17 +238,17 @@
     </tr>
   </tbody>
     <tfoot class="gt_sourcenotes">
-    
+
     <tr>
       <td class="gt_sourcenote" colspan="3">Significance levels: * p &lt; 0.1, ** p &lt; 0.05, *** p &lt; 0.01. Format of coefficient cell: Coefficient   (Std. Error)</td>
     </tr>
-  
+
   </tfoot>
-  
+
   </table>
-  
+
   </div>
-          
+
   '''
 # ---
 # name: TestETableCoefSelection.test_coef_selection[exact_match-latex]
@@ -279,7 +279,7 @@
   \endgroup
   \noindent\begin{minipage}{\linewidth}\smallskip\footnotesize
   Significance levels: * p < 0.1, ** p < 0.05, *** p < 0.01. Format of coefficient cell: Coefficient   (Std. Error)\end{minipage}
-  
+
   \end{threeparttable}
   '''
 # ---
@@ -314,7 +314,7 @@
             -webkit-font-smoothing: antialiased;
             -moz-osx-font-smoothing: grayscale;
           }
-  
+
   #STABLE_ID thead, tbody, tfoot, tr, td, th { border-style: none; }
    tr { background-color: transparent; }
   #STABLE_ID p { margin: 0; padding: 0; }
@@ -353,11 +353,11 @@
    #STABLE_ID .gt_super { font-size: 65%; }
    #STABLE_ID .gt_footnote_marks { font-size: 75%; vertical-align: 0.4em; position: initial; }
    #STABLE_ID .gt_asterisk { font-size: 100%; vertical-align: 0; }
-   
+
   </style>
   <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>
-  
+
   <tr class="gt_col_headings gt_spanner_row">
     <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="2" colspan="1" scope="col" id=""></th>
     <th class="gt_center gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="2" scope="colgroup" id="y">
@@ -403,17 +403,17 @@
     </tr>
   </tbody>
     <tfoot class="gt_sourcenotes">
-    
+
     <tr>
       <td class="gt_sourcenote" colspan="3">Significance levels: * p &lt; 0.1, ** p &lt; 0.05, *** p &lt; 0.01. Format of coefficient cell: Coefficient   (Std. Error)</td>
     </tr>
-  
+
   </tfoot>
-  
+
   </table>
-  
+
   </div>
-          
+
   '''
 # ---
 # name: TestETableCoefSelection.test_coef_selection[keep_reorders-latex]
@@ -450,7 +450,7 @@
   \endgroup
   \noindent\begin{minipage}{\linewidth}\smallskip\footnotesize
   Significance levels: * p < 0.1, ** p < 0.05, *** p < 0.01. Format of coefficient cell: Coefficient   (Std. Error)\end{minipage}
-  
+
   \end{threeparttable}
   '''
 # ---
@@ -487,7 +487,7 @@
             -webkit-font-smoothing: antialiased;
             -moz-osx-font-smoothing: grayscale;
           }
-  
+
   #STABLE_ID thead, tbody, tfoot, tr, td, th { border-style: none; }
    tr { background-color: transparent; }
   #STABLE_ID p { margin: 0; padding: 0; }
@@ -526,11 +526,11 @@
    #STABLE_ID .gt_super { font-size: 65%; }
    #STABLE_ID .gt_footnote_marks { font-size: 75%; vertical-align: 0.4em; position: initial; }
    #STABLE_ID .gt_asterisk { font-size: 100%; vertical-align: 0; }
-   
+
   </style>
   <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>
-  
+
   <tr class="gt_col_headings gt_spanner_row">
     <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="2" colspan="1" scope="col" id=""></th>
     <th class="gt_center gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="2" scope="colgroup" id="y">
@@ -566,17 +566,17 @@
     </tr>
   </tbody>
     <tfoot class="gt_sourcenotes">
-    
+
     <tr>
       <td class="gt_sourcenote" colspan="3">Significance levels: * p &lt; 0.1, ** p &lt; 0.05, *** p &lt; 0.01. Format of coefficient cell: Coefficient   (Std. Error)</td>
     </tr>
-  
+
   </tfoot>
-  
+
   </table>
-  
+
   </div>
-          
+
   '''
 # ---
 # name: TestETableCoefSelection.test_coef_selection[keep_single_coef-latex]
@@ -607,7 +607,7 @@
   \endgroup
   \noindent\begin{minipage}{\linewidth}\smallskip\footnotesize
   Significance levels: * p < 0.1, ** p < 0.05, *** p < 0.01. Format of coefficient cell: Coefficient   (Std. Error)\end{minipage}
-  
+
   \end{threeparttable}
   '''
 # ---
@@ -642,7 +642,7 @@
             -webkit-font-smoothing: antialiased;
             -moz-osx-font-smoothing: grayscale;
           }
-  
+
   #STABLE_ID thead, tbody, tfoot, tr, td, th { border-style: none; }
    tr { background-color: transparent; }
   #STABLE_ID p { margin: 0; padding: 0; }
@@ -681,11 +681,11 @@
    #STABLE_ID .gt_super { font-size: 65%; }
    #STABLE_ID .gt_footnote_marks { font-size: 75%; vertical-align: 0.4em; position: initial; }
    #STABLE_ID .gt_asterisk { font-size: 100%; vertical-align: 0; }
-   
+
   </style>
   <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>
-  
+
   <tr class="gt_col_headings gt_spanner_row">
     <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="2" colspan="1" scope="col" id=""></th>
     <th class="gt_center gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="2" scope="colgroup" id="y">
@@ -726,17 +726,17 @@
     </tr>
   </tbody>
     <tfoot class="gt_sourcenotes">
-    
+
     <tr>
       <td class="gt_sourcenote" colspan="3">Significance levels: * p &lt; 0.1, ** p &lt; 0.05, *** p &lt; 0.01. Format of coefficient cell: Coefficient   (Std. Error)</td>
     </tr>
-  
+
   </tfoot>
-  
+
   </table>
-  
+
   </div>
-          
+
   '''
 # ---
 # name: TestETableCoefSelection.test_coef_selection[keep_with_regex-latex]
@@ -770,7 +770,7 @@
   \endgroup
   \noindent\begin{minipage}{\linewidth}\smallskip\footnotesize
   Significance levels: * p < 0.1, ** p < 0.05, *** p < 0.01. Format of coefficient cell: Coefficient   (Std. Error)\end{minipage}
-  
+
   \end{threeparttable}
   '''
 # ---

--- a/tests/api/__snapshots__/test_stats.ambr
+++ b/tests/api/__snapshots__/test_stats.ambr
@@ -8,7 +8,7 @@
             -webkit-font-smoothing: antialiased;
             -moz-osx-font-smoothing: grayscale;
           }
-  
+
   #STABLE_ID thead, tbody, tfoot, tr, td, th { border-style: none; }
    tr { background-color: transparent; }
   #STABLE_ID p { margin: 0; padding: 0; }
@@ -47,11 +47,11 @@
    #STABLE_ID .gt_super { font-size: 65%; }
    #STABLE_ID .gt_footnote_marks { font-size: 75%; vertical-align: 0.4em; position: initial; }
    #STABLE_ID .gt_asterisk { font-size: 100%; vertical-align: 0; }
-   
+
   </style>
   <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>
-  
+
   <tr class="gt_col_headings gt_spanner_row">
     <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="2" colspan="1" scope="col" id=""></th>
     <th class="gt_center gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="1" scope="col" id="y">
@@ -91,17 +91,17 @@
     </tr>
   </tbody>
     <tfoot class="gt_sourcenotes">
-    
+
     <tr>
       <td class="gt_sourcenote" colspan="2">Significance levels: * p &lt; 0.1, ** p &lt; 0.05, *** p &lt; 0.01. Format of coefficient cell: Coefficient   (Std. Error)</td>
     </tr>
-  
+
   </tfoot>
-  
+
   </table>
-  
+
   </div>
-          
+
   '''
 # ---
 # name: TestETableModelStats.test_model_stats[aic_bic-latex]
@@ -138,7 +138,7 @@
   \endgroup
   \noindent\begin{minipage}{\linewidth}\smallskip\footnotesize
   Significance levels: * p < 0.1, ** p < 0.05, *** p < 0.01. Format of coefficient cell: Coefficient   (Std. Error)\end{minipage}
-  
+
   \end{threeparttable}
   '''
 # ---
@@ -175,7 +175,7 @@
             -webkit-font-smoothing: antialiased;
             -moz-osx-font-smoothing: grayscale;
           }
-  
+
   #STABLE_ID thead, tbody, tfoot, tr, td, th { border-style: none; }
    tr { background-color: transparent; }
   #STABLE_ID p { margin: 0; padding: 0; }
@@ -214,11 +214,11 @@
    #STABLE_ID .gt_super { font-size: 65%; }
    #STABLE_ID .gt_footnote_marks { font-size: 75%; vertical-align: 0.4em; position: initial; }
    #STABLE_ID .gt_asterisk { font-size: 100%; vertical-align: 0; }
-   
+
   </style>
   <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>
-  
+
   <tr class="gt_col_headings gt_spanner_row">
     <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="2" colspan="1" scope="col" id=""></th>
     <th class="gt_center gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="1" scope="col" id="y">
@@ -254,17 +254,17 @@
     </tr>
   </tbody>
     <tfoot class="gt_sourcenotes">
-    
+
     <tr>
       <td class="gt_sourcenote" colspan="2">Significance levels: * p &lt; 0.1, ** p &lt; 0.05, *** p &lt; 0.01. Format of coefficient cell: Coefficient   (Std. Error)</td>
     </tr>
-  
+
   </tfoot>
-  
+
   </table>
-  
+
   </div>
-          
+
   '''
 # ---
 # name: TestETableModelStats.test_model_stats[custom_labels-latex]
@@ -298,7 +298,7 @@
   \endgroup
   \noindent\begin{minipage}{\linewidth}\smallskip\footnotesize
   Significance levels: * p < 0.1, ** p < 0.05, *** p < 0.01. Format of coefficient cell: Coefficient   (Std. Error)\end{minipage}
-  
+
   \end{threeparttable}
   '''
 # ---
@@ -334,7 +334,7 @@
             -webkit-font-smoothing: antialiased;
             -moz-osx-font-smoothing: grayscale;
           }
-  
+
   #STABLE_ID thead, tbody, tfoot, tr, td, th { border-style: none; }
    tr { background-color: transparent; }
   #STABLE_ID p { margin: 0; padding: 0; }
@@ -373,11 +373,11 @@
    #STABLE_ID .gt_super { font-size: 65%; }
    #STABLE_ID .gt_footnote_marks { font-size: 75%; vertical-align: 0.4em; position: initial; }
    #STABLE_ID .gt_asterisk { font-size: 100%; vertical-align: 0; }
-   
+
   </style>
   <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>
-  
+
   <tr class="gt_col_headings gt_spanner_row">
     <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="2" colspan="1" scope="col" id=""></th>
     <th class="gt_center gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="1" scope="col" id="y">
@@ -421,17 +421,17 @@
     </tr>
   </tbody>
     <tfoot class="gt_sourcenotes">
-    
+
     <tr>
       <td class="gt_sourcenote" colspan="2">Significance levels: * p &lt; 0.1, ** p &lt; 0.05, *** p &lt; 0.01. Format of coefficient cell: Coefficient   (Std. Error)</td>
     </tr>
-  
+
   </tfoot>
-  
+
   </table>
-  
+
   </div>
-          
+
   '''
 # ---
 # name: TestETableModelStats.test_model_stats[extended-latex]
@@ -471,7 +471,7 @@
   \endgroup
   \noindent\begin{minipage}{\linewidth}\smallskip\footnotesize
   Significance levels: * p < 0.1, ** p < 0.05, *** p < 0.01. Format of coefficient cell: Coefficient   (Std. Error)\end{minipage}
-  
+
   \end{threeparttable}
   '''
 # ---
@@ -509,7 +509,7 @@
             -webkit-font-smoothing: antialiased;
             -moz-osx-font-smoothing: grayscale;
           }
-  
+
   #STABLE_ID thead, tbody, tfoot, tr, td, th { border-style: none; }
    tr { background-color: transparent; }
   #STABLE_ID p { margin: 0; padding: 0; }
@@ -548,11 +548,11 @@
    #STABLE_ID .gt_super { font-size: 65%; }
    #STABLE_ID .gt_footnote_marks { font-size: 75%; vertical-align: 0.4em; position: initial; }
    #STABLE_ID .gt_asterisk { font-size: 100%; vertical-align: 0; }
-   
+
   </style>
   <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>
-  
+
   <tr class="gt_col_headings gt_spanner_row">
     <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="2" colspan="1" scope="col" id=""></th>
     <th class="gt_center gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="1" scope="col" id="y">
@@ -584,17 +584,17 @@
     </tr>
   </tbody>
     <tfoot class="gt_sourcenotes">
-    
+
     <tr>
       <td class="gt_sourcenote" colspan="2">Significance levels: * p &lt; 0.1, ** p &lt; 0.05, *** p &lt; 0.01. Format of coefficient cell: Coefficient   (Std. Error)</td>
     </tr>
-  
+
   </tfoot>
-  
+
   </table>
-  
+
   </div>
-          
+
   '''
 # ---
 # name: TestETableModelStats.test_model_stats[minimal-latex]
@@ -625,7 +625,7 @@
   \endgroup
   \noindent\begin{minipage}{\linewidth}\smallskip\footnotesize
   Significance levels: * p < 0.1, ** p < 0.05, *** p < 0.01. Format of coefficient cell: Coefficient   (Std. Error)\end{minipage}
-  
+
   \end{threeparttable}
   '''
 # ---
@@ -660,7 +660,7 @@
             -webkit-font-smoothing: antialiased;
             -moz-osx-font-smoothing: grayscale;
           }
-  
+
   #STABLE_ID thead, tbody, tfoot, tr, td, th { border-style: none; }
    tr { background-color: transparent; }
   #STABLE_ID p { margin: 0; padding: 0; }
@@ -699,11 +699,11 @@
    #STABLE_ID .gt_super { font-size: 65%; }
    #STABLE_ID .gt_footnote_marks { font-size: 75%; vertical-align: 0.4em; position: initial; }
    #STABLE_ID .gt_asterisk { font-size: 100%; vertical-align: 0; }
-   
+
   </style>
   <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>
-  
+
   <tr class="gt_col_headings gt_spanner_row">
     <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="2" colspan="1" scope="col" id=""></th>
     <th class="gt_center gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="1" scope="col" id="y">
@@ -743,17 +743,17 @@
     </tr>
   </tbody>
     <tfoot class="gt_sourcenotes">
-    
+
     <tr>
       <td class="gt_sourcenote" colspan="2">Significance levels: * p &lt; 0.1, ** p &lt; 0.05, *** p &lt; 0.01. Format of coefficient cell: Coefficient   (Std. Error)</td>
     </tr>
-  
+
   </tfoot>
-  
+
   </table>
-  
+
   </div>
-          
+
   '''
 # ---
 # name: TestETableModelStats.test_model_stats[with_se_type-latex]
@@ -790,7 +790,7 @@
   \endgroup
   \noindent\begin{minipage}{\linewidth}\smallskip\footnotesize
   Significance levels: * p < 0.1, ** p < 0.05, *** p < 0.01. Format of coefficient cell: Coefficient   (Std. Error)\end{minipage}
-  
+
   \end{threeparttable}
   '''
 # ---

--- a/tests/api/__snapshots__/test_stats.ambr
+++ b/tests/api/__snapshots__/test_stats.ambr
@@ -818,3 +818,43 @@
   )
   '''
 # ---
+# name: test_btable_mean_std_suppresses_std_for_binary_variables
+  '''
+  ,A,B,
+  ,Mean (Std. Dev.),Mean (Std. Dev.),p-value
+  binary,0.50,0.50,1.000
+  continuous,1.75 (0.65),4.75 (0.65),0.001
+  '''
+# ---
+# name: test_dtable_mean_newline_std_suppresses_std_for_grouped_binary_variables
+  '''
+  ,A,B
+  ,Mean (Std. Dev.),Mean (Std. Dev.)
+  binary,0.50,0.50
+  continuous,"1.75
+  (0.65)","4.75
+  (0.65)"
+  '''
+# ---
+# name: test_dtable_mean_std_suppresses_std_for_binary_variables
+  '''
+  ,Mean (Std. Dev.)
+  binary,0.50
+  continuous,3.25 (1.71)
+  '''
+# ---
+# name: test_is_binary_series_detects_two_unique_nonmissing_values
+  dict({
+    'all_missing': False,
+    'bool_binary': True,
+    'categorical_binary': False,
+    'datetime_binary': False,
+    'float_binary': True,
+    'int_binary': True,
+    'non_indicator_numeric_binary': True,
+    'nullable_bool_binary': True,
+    'single_level': False,
+    'string_binary': False,
+    'three_level': False,
+  })
+# ---

--- a/tests/api/__snapshots__/test_stats.ambr
+++ b/tests/api/__snapshots__/test_stats.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: TestETableModelStats.test_model_stats_aic_bic_html
+# name: TestETableModelStats.test_model_stats[aic_bic-html]
   '''
   <div id="STABLE_ID" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
   <style>
@@ -104,7 +104,7 @@
           
   '''
 # ---
-# name: TestETableModelStats.test_model_stats_aic_bic_latex
+# name: TestETableModelStats.test_model_stats[aic_bic-latex]
   '''
   \begin{threeparttable}
   \begingroup
@@ -142,7 +142,7 @@
   \end{threeparttable}
   '''
 # ---
-# name: TestETableModelStats.test_model_stats_aic_bic_typst
+# name: TestETableModelStats.test_model_stats[aic_bic-typst]
   '''
   #table(
     columns: (auto, 1fr), align: (left, center),
@@ -166,7 +166,7 @@
   )
   '''
 # ---
-# name: TestETableModelStats.test_model_stats_custom_labels_html
+# name: TestETableModelStats.test_model_stats[custom_labels-html]
   '''
   <div id="STABLE_ID" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
   <style>
@@ -267,7 +267,7 @@
           
   '''
 # ---
-# name: TestETableModelStats.test_model_stats_custom_labels_latex
+# name: TestETableModelStats.test_model_stats[custom_labels-latex]
   '''
   \begin{threeparttable}
   \begingroup
@@ -302,7 +302,7 @@
   \end{threeparttable}
   '''
 # ---
-# name: TestETableModelStats.test_model_stats_custom_labels_typst
+# name: TestETableModelStats.test_model_stats[custom_labels-typst]
   '''
   #table(
     columns: (auto, 1fr), align: (left, center),
@@ -325,7 +325,7 @@
   )
   '''
 # ---
-# name: TestETableModelStats.test_model_stats_extended_html
+# name: TestETableModelStats.test_model_stats[extended-html]
   '''
   <div id="STABLE_ID" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
   <style>
@@ -434,7 +434,7 @@
           
   '''
 # ---
-# name: TestETableModelStats.test_model_stats_extended_latex
+# name: TestETableModelStats.test_model_stats[extended-latex]
   '''
   \begin{threeparttable}
   \begingroup
@@ -475,7 +475,7 @@
   \end{threeparttable}
   '''
 # ---
-# name: TestETableModelStats.test_model_stats_extended_typst
+# name: TestETableModelStats.test_model_stats[extended-typst]
   '''
   #table(
     columns: (auto, 1fr), align: (left, center),
@@ -500,7 +500,7 @@
   )
   '''
 # ---
-# name: TestETableModelStats.test_model_stats_minimal_html
+# name: TestETableModelStats.test_model_stats[minimal-html]
   '''
   <div id="STABLE_ID" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
   <style>
@@ -597,7 +597,7 @@
           
   '''
 # ---
-# name: TestETableModelStats.test_model_stats_minimal_latex
+# name: TestETableModelStats.test_model_stats[minimal-latex]
   '''
   \begin{threeparttable}
   \begingroup
@@ -629,7 +629,7 @@
   \end{threeparttable}
   '''
 # ---
-# name: TestETableModelStats.test_model_stats_minimal_typst
+# name: TestETableModelStats.test_model_stats[minimal-typst]
   '''
   #table(
     columns: (auto, 1fr), align: (left, center),
@@ -651,7 +651,7 @@
   )
   '''
 # ---
-# name: TestETableModelStats.test_model_stats_with_se_type_html
+# name: TestETableModelStats.test_model_stats[with_se_type-html]
   '''
   <div id="STABLE_ID" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
   <style>
@@ -756,7 +756,7 @@
           
   '''
 # ---
-# name: TestETableModelStats.test_model_stats_with_se_type_latex
+# name: TestETableModelStats.test_model_stats[with_se_type-latex]
   '''
   \begin{threeparttable}
   \begingroup
@@ -794,7 +794,7 @@
   \end{threeparttable}
   '''
 # ---
-# name: TestETableModelStats.test_model_stats_with_se_type_typst
+# name: TestETableModelStats.test_model_stats[with_se_type-typst]
   '''
   #table(
     columns: (auto, 1fr), align: (left, center),

--- a/tests/api/__snapshots__/test_stats.ambr
+++ b/tests/api/__snapshots__/test_stats.ambr
@@ -818,6 +818,15 @@
   )
   '''
 # ---
+# name: test_btable_accepts_list_group_for_column_combinations
+  '''
+  ,control,control,treated,treated,
+  ,post,pre,post,pre,
+  ,Mean,Mean,Mean,Mean,p-value
+  x,3.10,2.10,3.60,2.60,0.294
+  z,3.35,2.85,3.45,2.95,0.714
+  '''
+# ---
 # name: test_btable_mean_std_suppresses_std_for_binary_variables
   '''
   ,A,B,

--- a/tests/api/__snapshots__/test_stats.ambr
+++ b/tests/api/__snapshots__/test_stats.ambr
@@ -142,6 +142,30 @@
   \end{threeparttable}
   '''
 # ---
+# name: TestETableModelStats.test_model_stats_aic_bic_typst
+  '''
+  #table(
+    columns: (auto, 1fr), align: (left, center),
+    column-gutter: (0em),
+    stroke: none, row-gutter: 0.2em,
+    table.hline(stroke: 0.08em),
+    [], [#table.cell(colspan: 1)[y]],
+    table.hline(stroke: 0.03em, start: 1, end: 2),
+    [], [(1)],
+    table.hline(stroke: 0.05em),
+    table.hline(stroke: 0.03em),
+    [x], [2.000\*\*\* \ (0.000)],
+    [Intercept], [0.100\*\*\* \ (0.000)],
+    table.hline(stroke: 0.03em),
+    table.hline(stroke: 0.03em),
+    [Observations], [100],
+    [AIC], [-],
+    [BIC], [-],
+    table.hline(stroke: 0.08em),
+    [#table.cell(colspan: 2)[#text(size: 10pt)[Significance levels: \* p \< 0.1, \*\* p \< 0.05, \*\*\* p \< 0.01. Format of coefficient cell: Coefficient   (Std. Error)]]],
+  )
+  '''
+# ---
 # name: TestETableModelStats.test_model_stats_custom_labels_html
   '''
   <div id="STABLE_ID" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
@@ -276,6 +300,29 @@
   Significance levels: * p < 0.1, ** p < 0.05, *** p < 0.01. Format of coefficient cell: Coefficient   (Std. Error)\end{minipage}
   
   \end{threeparttable}
+  '''
+# ---
+# name: TestETableModelStats.test_model_stats_custom_labels_typst
+  '''
+  #table(
+    columns: (auto, 1fr), align: (left, center),
+    column-gutter: (0em),
+    stroke: none, row-gutter: 0.2em,
+    table.hline(stroke: 0.08em),
+    [], [#table.cell(colspan: 1)[y]],
+    table.hline(stroke: 0.03em, start: 1, end: 2),
+    [], [(1)],
+    table.hline(stroke: 0.05em),
+    table.hline(stroke: 0.03em),
+    [x], [2.000\*\*\* \ (0.000)],
+    [Intercept], [0.100\*\*\* \ (0.000)],
+    table.hline(stroke: 0.03em),
+    table.hline(stroke: 0.03em),
+    [Sample Size], [100],
+    [R-squared], [1],
+    table.hline(stroke: 0.08em),
+    [#table.cell(colspan: 2)[#text(size: 10pt)[Significance levels: \* p \< 0.1, \*\* p \< 0.05, \*\*\* p \< 0.01. Format of coefficient cell: Coefficient   (Std. Error)]]],
+  )
   '''
 # ---
 # name: TestETableModelStats.test_model_stats_extended_html
@@ -428,6 +475,31 @@
   \end{threeparttable}
   '''
 # ---
+# name: TestETableModelStats.test_model_stats_extended_typst
+  '''
+  #table(
+    columns: (auto, 1fr), align: (left, center),
+    column-gutter: (0em),
+    stroke: none, row-gutter: 0.2em,
+    table.hline(stroke: 0.08em),
+    [], [#table.cell(colspan: 1)[y]],
+    table.hline(stroke: 0.03em, start: 1, end: 2),
+    [], [(1)],
+    table.hline(stroke: 0.05em),
+    table.hline(stroke: 0.03em),
+    [x], [2.000\*\*\* \ (0.000)],
+    [Intercept], [0.100\*\*\* \ (0.000)],
+    table.hline(stroke: 0.03em),
+    table.hline(stroke: 0.03em),
+    [Observations], [100],
+    [$R^2$], [1],
+    [Adj. $R^2$], [-],
+    [RMSE], [0],
+    table.hline(stroke: 0.08em),
+    [#table.cell(colspan: 2)[#text(size: 10pt)[Significance levels: \* p \< 0.1, \*\* p \< 0.05, \*\*\* p \< 0.01. Format of coefficient cell: Coefficient   (Std. Error)]]],
+  )
+  '''
+# ---
 # name: TestETableModelStats.test_model_stats_minimal_html
   '''
   <div id="STABLE_ID" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
@@ -555,6 +627,28 @@
   Significance levels: * p < 0.1, ** p < 0.05, *** p < 0.01. Format of coefficient cell: Coefficient   (Std. Error)\end{minipage}
   
   \end{threeparttable}
+  '''
+# ---
+# name: TestETableModelStats.test_model_stats_minimal_typst
+  '''
+  #table(
+    columns: (auto, 1fr), align: (left, center),
+    column-gutter: (0em),
+    stroke: none, row-gutter: 0.2em,
+    table.hline(stroke: 0.08em),
+    [], [#table.cell(colspan: 1)[y]],
+    table.hline(stroke: 0.03em, start: 1, end: 2),
+    [], [(1)],
+    table.hline(stroke: 0.05em),
+    table.hline(stroke: 0.03em),
+    [x], [2.000\*\*\* \ (0.000)],
+    [Intercept], [0.100\*\*\* \ (0.000)],
+    table.hline(stroke: 0.03em),
+    table.hline(stroke: 0.03em),
+    [Observations], [100],
+    table.hline(stroke: 0.08em),
+    [#table.cell(colspan: 2)[#text(size: 10pt)[Significance levels: \* p \< 0.1, \*\* p \< 0.05, \*\*\* p \< 0.01. Format of coefficient cell: Coefficient   (Std. Error)]]],
+  )
   '''
 # ---
 # name: TestETableModelStats.test_model_stats_with_se_type_html
@@ -698,5 +792,29 @@
   Significance levels: * p < 0.1, ** p < 0.05, *** p < 0.01. Format of coefficient cell: Coefficient   (Std. Error)\end{minipage}
   
   \end{threeparttable}
+  '''
+# ---
+# name: TestETableModelStats.test_model_stats_with_se_type_typst
+  '''
+  #table(
+    columns: (auto, 1fr), align: (left, center),
+    column-gutter: (0em),
+    stroke: none, row-gutter: 0.2em,
+    table.hline(stroke: 0.08em),
+    [], [#table.cell(colspan: 1)[y]],
+    table.hline(stroke: 0.03em, start: 1, end: 2),
+    [], [(1)],
+    table.hline(stroke: 0.05em),
+    table.hline(stroke: 0.03em),
+    [x], [2.000\*\*\* \ (0.000)],
+    [Intercept], [0.100\*\*\* \ (0.000)],
+    table.hline(stroke: 0.03em),
+    table.hline(stroke: 0.03em),
+    [Observations], [100],
+    [$R^2$], [1],
+    [S.E. type], [iid],
+    table.hline(stroke: 0.08em),
+    [#table.cell(colspan: 2)[#text(size: 10pt)[Significance levels: \* p \< 0.1, \*\* p \< 0.05, \*\*\* p \< 0.01. Format of coefficient cell: Coefficient   (Std. Error)]]],
+  )
   '''
 # ---

--- a/tests/api/test_formatting.py
+++ b/tests/api/test_formatting.py
@@ -1,83 +1,26 @@
 """Snapshot tests for ETable coefficient formatting."""
 
 import maketables as mt
-from helpers import normalize_html
+import pytest
+from helpers import OUTPUT_TYPES, render_table
 
 
 class TestETableCoefFormat:
     """Snapshot tests for coef_fmt variations."""
 
-    def test_coef_fmt_default_html(self, fitted_model, snapshot):
-        """Default coefficient format (b with SE)."""
-        table = mt.ETable([fitted_model])
-        assert normalize_html(table.make(type="gt").as_raw_html()) == snapshot
-
-    def test_coef_fmt_default_latex(self, fitted_model, snapshot):
-        """Default coefficient format (b with SE)."""
-        table = mt.ETable([fitted_model])
-        assert table.make(type="tex") == snapshot
-
-    def test_coef_fmt_default_typst(self, fitted_model, snapshot):
-        """Default coefficient format (b with SE) in Typst."""
-        table = mt.ETable([fitted_model])
-        assert table.make(type="typst") == snapshot
-
-    def test_coef_fmt_with_tstat_html(self, fitted_model, snapshot):
-        """Coefficient with t-statistic in brackets."""
-        table = mt.ETable([fitted_model], coef_fmt="b:.3f \n [t:.2f]")
-        assert normalize_html(table.make(type="gt").as_raw_html()) == snapshot
-
-    def test_coef_fmt_with_tstat_latex(self, fitted_model, snapshot):
-        """Coefficient with t-statistic in brackets."""
-        table = mt.ETable([fitted_model], coef_fmt="b:.3f \n [t:.2f]")
-        assert table.make(type="tex") == snapshot
-
-    def test_coef_fmt_with_tstat_typst(self, fitted_model, snapshot):
-        """Coefficient with t-statistic in brackets in Typst."""
-        table = mt.ETable([fitted_model], coef_fmt="b:.3f \n [t:.2f]")
-        assert table.make(type="typst") == snapshot
-
-    def test_coef_fmt_with_pvalue_html(self, fitted_model, snapshot):
-        """Coefficient with p-value."""
-        table = mt.ETable([fitted_model], coef_fmt="b:.3f \n (p:.4f)")
-        assert normalize_html(table.make(type="gt").as_raw_html()) == snapshot
-
-    def test_coef_fmt_with_pvalue_latex(self, fitted_model, snapshot):
-        """Coefficient with p-value."""
-        table = mt.ETable([fitted_model], coef_fmt="b:.3f \n (p:.4f)")
-        assert table.make(type="tex") == snapshot
-
-    def test_coef_fmt_with_pvalue_typst(self, fitted_model, snapshot):
-        """Coefficient with p-value in Typst."""
-        table = mt.ETable([fitted_model], coef_fmt="b:.3f \n (p:.4f)")
-        assert table.make(type="typst") == snapshot
-
-    def test_coef_fmt_all_stats_html(self, fitted_model, snapshot):
-        """Coefficient with SE and t-statistic."""
-        table = mt.ETable([fitted_model], coef_fmt="b:.3f \n (se:.3f) \n [t:.2f]")
-        assert normalize_html(table.make(type="gt").as_raw_html()) == snapshot
-
-    def test_coef_fmt_all_stats_latex(self, fitted_model, snapshot):
-        """Coefficient with SE and t-statistic."""
-        table = mt.ETable([fitted_model], coef_fmt="b:.3f \n (se:.3f) \n [t:.2f]")
-        assert table.make(type="tex") == snapshot
-
-    def test_coef_fmt_all_stats_typst(self, fitted_model, snapshot):
-        """Coefficient with SE and t-statistic in Typst."""
-        table = mt.ETable([fitted_model], coef_fmt="b:.3f \n (se:.3f) \n [t:.2f]")
-        assert table.make(type="typst") == snapshot
-
-    def test_coef_fmt_different_decimals_html(self, fitted_model, snapshot):
-        """Different decimal places for coefficient and SE."""
-        table = mt.ETable([fitted_model], coef_fmt="b:.4f \n (se:.2f)")
-        assert normalize_html(table.make(type="gt").as_raw_html()) == snapshot
-
-    def test_coef_fmt_different_decimals_latex(self, fitted_model, snapshot):
-        """Different decimal places for coefficient and SE."""
-        table = mt.ETable([fitted_model], coef_fmt="b:.4f \n (se:.2f)")
-        assert table.make(type="tex") == snapshot
-
-    def test_coef_fmt_different_decimals_typst(self, fitted_model, snapshot):
-        """Different decimal places for coefficient and SE in Typst."""
-        table = mt.ETable([fitted_model], coef_fmt="b:.4f \n (se:.2f)")
-        assert table.make(type="typst") == snapshot
+    @pytest.mark.parametrize("output_type", OUTPUT_TYPES)
+    @pytest.mark.parametrize(
+        "coef_fmt",
+        [
+            pytest.param(None, id="default"),
+            pytest.param("b:.3f \n [t:.2f]", id="with_tstat"),
+            pytest.param("b:.3f \n (p:.4f)", id="with_pvalue"),
+            pytest.param("b:.3f \n (se:.3f) \n [t:.2f]", id="all_stats"),
+            pytest.param("b:.4f \n (se:.2f)", id="different_decimals"),
+        ],
+    )
+    def test_coef_fmt(self, fitted_model, snapshot, coef_fmt, output_type):
+        """Coefficient format variations."""
+        kwargs = {} if coef_fmt is None else {"coef_fmt": coef_fmt}
+        table = mt.ETable([fitted_model], **kwargs)
+        assert render_table(table, output_type) == snapshot

--- a/tests/api/test_formatting.py
+++ b/tests/api/test_formatting.py
@@ -1,8 +1,9 @@
 """Snapshot tests for ETable coefficient formatting."""
 
-import maketables as mt
 import pytest
 from helpers import OUTPUT_TYPES, render_table
+
+import maketables as mt
 
 
 class TestETableCoefFormat:

--- a/tests/api/test_formatting.py
+++ b/tests/api/test_formatting.py
@@ -17,6 +17,11 @@ class TestETableCoefFormat:
         table = mt.ETable([fitted_model])
         assert table.make(type="tex") == snapshot
 
+    def test_coef_fmt_default_typst(self, fitted_model, snapshot):
+        """Default coefficient format (b with SE) in Typst."""
+        table = mt.ETable([fitted_model])
+        assert table.make(type="typst") == snapshot
+
     def test_coef_fmt_with_tstat_html(self, fitted_model, snapshot):
         """Coefficient with t-statistic in brackets."""
         table = mt.ETable([fitted_model], coef_fmt="b:.3f \n [t:.2f]")
@@ -26,6 +31,11 @@ class TestETableCoefFormat:
         """Coefficient with t-statistic in brackets."""
         table = mt.ETable([fitted_model], coef_fmt="b:.3f \n [t:.2f]")
         assert table.make(type="tex") == snapshot
+
+    def test_coef_fmt_with_tstat_typst(self, fitted_model, snapshot):
+        """Coefficient with t-statistic in brackets in Typst."""
+        table = mt.ETable([fitted_model], coef_fmt="b:.3f \n [t:.2f]")
+        assert table.make(type="typst") == snapshot
 
     def test_coef_fmt_with_pvalue_html(self, fitted_model, snapshot):
         """Coefficient with p-value."""
@@ -37,6 +47,11 @@ class TestETableCoefFormat:
         table = mt.ETable([fitted_model], coef_fmt="b:.3f \n (p:.4f)")
         assert table.make(type="tex") == snapshot
 
+    def test_coef_fmt_with_pvalue_typst(self, fitted_model, snapshot):
+        """Coefficient with p-value in Typst."""
+        table = mt.ETable([fitted_model], coef_fmt="b:.3f \n (p:.4f)")
+        assert table.make(type="typst") == snapshot
+
     def test_coef_fmt_all_stats_html(self, fitted_model, snapshot):
         """Coefficient with SE and t-statistic."""
         table = mt.ETable([fitted_model], coef_fmt="b:.3f \n (se:.3f) \n [t:.2f]")
@@ -47,6 +62,11 @@ class TestETableCoefFormat:
         table = mt.ETable([fitted_model], coef_fmt="b:.3f \n (se:.3f) \n [t:.2f]")
         assert table.make(type="tex") == snapshot
 
+    def test_coef_fmt_all_stats_typst(self, fitted_model, snapshot):
+        """Coefficient with SE and t-statistic in Typst."""
+        table = mt.ETable([fitted_model], coef_fmt="b:.3f \n (se:.3f) \n [t:.2f]")
+        assert table.make(type="typst") == snapshot
+
     def test_coef_fmt_different_decimals_html(self, fitted_model, snapshot):
         """Different decimal places for coefficient and SE."""
         table = mt.ETable([fitted_model], coef_fmt="b:.4f \n (se:.2f)")
@@ -56,3 +76,8 @@ class TestETableCoefFormat:
         """Different decimal places for coefficient and SE."""
         table = mt.ETable([fitted_model], coef_fmt="b:.4f \n (se:.2f)")
         assert table.make(type="tex") == snapshot
+
+    def test_coef_fmt_different_decimals_typst(self, fitted_model, snapshot):
+        """Different decimal places for coefficient and SE in Typst."""
+        table = mt.ETable([fitted_model], coef_fmt="b:.4f \n (se:.2f)")
+        assert table.make(type="typst") == snapshot

--- a/tests/api/test_selection.py
+++ b/tests/api/test_selection.py
@@ -1,8 +1,9 @@
 """Snapshot tests for ETable coefficient selection (keep/drop)."""
 
-import maketables as mt
 import pytest
 from helpers import OUTPUT_TYPES, render_table
+
+import maketables as mt
 
 
 class TestETableCoefSelection:

--- a/tests/api/test_selection.py
+++ b/tests/api/test_selection.py
@@ -17,6 +17,14 @@ class TestETableCoefSelection:
         table = mt.ETable(fitted_models, keep=["x"])
         assert table.make(type="tex") == snapshot
 
+    def test_keep_multiple_coefs_typst(self, fitted_models, snapshot):
+        """Keep multiple coefficients (x and C(group)) in Typst."""
+        table = mt.ETable(
+            fitted_models,
+            keep=["x"],
+        )
+        assert table.make(type="typst") == snapshot
+
     def test_drop_intercept_html(self, fitted_model, snapshot):
         """Drop intercept from table."""
         table = mt.ETable([fitted_model], drop=["Intercept"])
@@ -26,6 +34,11 @@ class TestETableCoefSelection:
         """Drop intercept from table."""
         table = mt.ETable([fitted_model], drop=["Intercept"])
         assert table.make(type="tex") == snapshot
+
+    def test_drop_intercept_typst(self, fitted_model, snapshot):
+        """Drop intercept from table in Typst."""
+        table = mt.ETable([fitted_model], drop=["Intercept"])
+        assert table.make(type="typst") == snapshot
 
     def test_keep_with_regex_html(self, fitted_models, snapshot):
         """Keep coefficients using regex pattern."""
@@ -37,6 +50,11 @@ class TestETableCoefSelection:
         table = mt.ETable(fitted_models, keep=["x", "C\\(group\\)"])
         assert table.make(type="tex") == snapshot
 
+    def test_keep_with_regex_typst(self, fitted_models, snapshot):
+        """Keep coefficients using regex pattern in Typst."""
+        table = mt.ETable(fitted_models, keep=["x", "C\\(group\\)"])
+        assert table.make(type="typst") == snapshot
+
     def test_exact_match_html(self, fitted_models, snapshot):
         """Exact match mode (no regex)."""
         table = mt.ETable(fitted_models, keep=["x"], exact_match=True)
@@ -47,6 +65,11 @@ class TestETableCoefSelection:
         table = mt.ETable(fitted_models, keep=["x"], exact_match=True)
         assert table.make(type="tex") == snapshot
 
+    def test_exact_match_typst(self, fitted_models, snapshot):
+        """Exact match mode (no regex) in Typst."""
+        table = mt.ETable(fitted_models, keep=["x"], exact_match=True)
+        assert table.make(type="typst") == snapshot
+
     def test_keep_reorders_html(self, fitted_models, snapshot):
         """Keep reorders coefficients according to pattern order."""
         table = mt.ETable(fitted_models, keep=["C\\(group\\)", "x", "Intercept"])
@@ -56,3 +79,8 @@ class TestETableCoefSelection:
         """Keep reorders coefficients according to pattern order."""
         table = mt.ETable(fitted_models, keep=["C\\(group\\)", "x", "Intercept"])
         assert table.make(type="tex") == snapshot
+
+    def test_keep_reorders_typst(self, fitted_models, snapshot):
+        """Keep reorders coefficients according to pattern order in Typst."""
+        table = mt.ETable(fitted_models, keep=["C\\(group\\)", "x", "Intercept"])
+        assert table.make(type="typst") == snapshot

--- a/tests/api/test_selection.py
+++ b/tests/api/test_selection.py
@@ -1,86 +1,48 @@
 """Snapshot tests for ETable coefficient selection (keep/drop)."""
 
 import maketables as mt
-from helpers import normalize_html
+import pytest
+from helpers import OUTPUT_TYPES, render_table
 
 
 class TestETableCoefSelection:
     """Snapshot tests for keep/drop coefficient filtering."""
 
-    def test_keep_single_coef_html(self, fitted_models, snapshot):
-        """Keep only x coefficient."""
-        table = mt.ETable(fitted_models, keep=["x"])
-        assert normalize_html(table.make(type="gt").as_raw_html()) == snapshot
+    @pytest.mark.parametrize("output_type", OUTPUT_TYPES)
+    @pytest.mark.parametrize(
+        "model_fixture, table_kwargs",
+        [
+            pytest.param("fitted_models", {"keep": ["x"]}, id="keep_single_coef"),
+            pytest.param("fitted_model", {"drop": ["Intercept"]}, id="drop_intercept"),
+            pytest.param(
+                "fitted_models",
+                {"keep": ["x", "C\\(group\\)"]},
+                id="keep_with_regex",
+            ),
+            pytest.param(
+                "fitted_models",
+                {"keep": ["x"], "exact_match": True},
+                id="exact_match",
+            ),
+            pytest.param(
+                "fitted_models",
+                {"keep": ["C\\(group\\)", "x", "Intercept"]},
+                id="keep_reorders",
+            ),
+        ],
+    )
+    def test_coef_selection(
+        self,
+        request,
+        snapshot,
+        model_fixture,
+        table_kwargs,
+        output_type,
+    ):
+        """Coefficient selection variations."""
+        models = request.getfixturevalue(model_fixture)
+        if not isinstance(models, list):
+            models = [models]
 
-    def test_keep_single_coef_latex(self, fitted_models, snapshot):
-        """Keep only x coefficient."""
-        table = mt.ETable(fitted_models, keep=["x"])
-        assert table.make(type="tex") == snapshot
-
-    def test_keep_multiple_coefs_typst(self, fitted_models, snapshot):
-        """Keep multiple coefficients (x and C(group)) in Typst."""
-        table = mt.ETable(
-            fitted_models,
-            keep=["x"],
-        )
-        assert table.make(type="typst") == snapshot
-
-    def test_drop_intercept_html(self, fitted_model, snapshot):
-        """Drop intercept from table."""
-        table = mt.ETable([fitted_model], drop=["Intercept"])
-        assert normalize_html(table.make(type="gt").as_raw_html()) == snapshot
-
-    def test_drop_intercept_latex(self, fitted_model, snapshot):
-        """Drop intercept from table."""
-        table = mt.ETable([fitted_model], drop=["Intercept"])
-        assert table.make(type="tex") == snapshot
-
-    def test_drop_intercept_typst(self, fitted_model, snapshot):
-        """Drop intercept from table in Typst."""
-        table = mt.ETable([fitted_model], drop=["Intercept"])
-        assert table.make(type="typst") == snapshot
-
-    def test_keep_with_regex_html(self, fitted_models, snapshot):
-        """Keep coefficients using regex pattern."""
-        table = mt.ETable(fitted_models, keep=["x", "C\\(group\\)"])
-        assert normalize_html(table.make(type="gt").as_raw_html()) == snapshot
-
-    def test_keep_with_regex_latex(self, fitted_models, snapshot):
-        """Keep coefficients using regex pattern."""
-        table = mt.ETable(fitted_models, keep=["x", "C\\(group\\)"])
-        assert table.make(type="tex") == snapshot
-
-    def test_keep_with_regex_typst(self, fitted_models, snapshot):
-        """Keep coefficients using regex pattern in Typst."""
-        table = mt.ETable(fitted_models, keep=["x", "C\\(group\\)"])
-        assert table.make(type="typst") == snapshot
-
-    def test_exact_match_html(self, fitted_models, snapshot):
-        """Exact match mode (no regex)."""
-        table = mt.ETable(fitted_models, keep=["x"], exact_match=True)
-        assert normalize_html(table.make(type="gt").as_raw_html()) == snapshot
-
-    def test_exact_match_latex(self, fitted_models, snapshot):
-        """Exact match mode (no regex)."""
-        table = mt.ETable(fitted_models, keep=["x"], exact_match=True)
-        assert table.make(type="tex") == snapshot
-
-    def test_exact_match_typst(self, fitted_models, snapshot):
-        """Exact match mode (no regex) in Typst."""
-        table = mt.ETable(fitted_models, keep=["x"], exact_match=True)
-        assert table.make(type="typst") == snapshot
-
-    def test_keep_reorders_html(self, fitted_models, snapshot):
-        """Keep reorders coefficients according to pattern order."""
-        table = mt.ETable(fitted_models, keep=["C\\(group\\)", "x", "Intercept"])
-        assert normalize_html(table.make(type="gt").as_raw_html()) == snapshot
-
-    def test_keep_reorders_latex(self, fitted_models, snapshot):
-        """Keep reorders coefficients according to pattern order."""
-        table = mt.ETable(fitted_models, keep=["C\\(group\\)", "x", "Intercept"])
-        assert table.make(type="tex") == snapshot
-
-    def test_keep_reorders_typst(self, fitted_models, snapshot):
-        """Keep reorders coefficients according to pattern order in Typst."""
-        table = mt.ETable(fitted_models, keep=["C\\(group\\)", "x", "Intercept"])
-        assert table.make(type="typst") == snapshot
+        table = mt.ETable(models, **table_kwargs)
+        assert render_table(table, output_type) == snapshot

--- a/tests/api/test_stats.py
+++ b/tests/api/test_stats.py
@@ -1,9 +1,10 @@
-"""Snapshot tests for ETable model statistics."""
+"""Snapshot tests for table statistics."""
 
 import pytest
 from helpers import OUTPUT_TYPES, render_table
 
 import maketables as mt
+from maketables.dtable import _is_binary_series
 
 
 class TestETableModelStats:
@@ -39,3 +40,56 @@ class TestETableModelStats:
             model_stats_labels=model_stats_labels,
         )
         assert render_table(table, output_type) == snapshot
+
+
+def test_dtable_mean_std_suppresses_std_for_binary_variables(
+    dtable_binary_df,
+    snapshot,
+):
+    table = mt.DTable(
+        dtable_binary_df,
+        vars=["binary", "continuous"],
+        stats=["mean_std"],
+    )
+
+    assert table.df.to_csv().strip() == snapshot
+
+
+def test_dtable_mean_newline_std_suppresses_std_for_grouped_binary_variables(
+    dtable_binary_df,
+    snapshot,
+):
+    table = mt.DTable(
+        dtable_binary_df,
+        vars=["binary", "continuous"],
+        stats=["mean_newline_std"],
+        bycol=["group"],
+    )
+
+    assert table.df.to_csv().strip() == snapshot
+
+
+def test_btable_mean_std_suppresses_std_for_binary_variables(
+    dtable_binary_df,
+    snapshot,
+):
+    pytest.importorskip("pyfixest")
+    table = mt.BTable(
+        dtable_binary_df,
+        vars=["binary", "continuous"],
+        group="group",
+        stats=["mean_std"],
+    )
+
+    assert table.df.to_csv().strip() == snapshot
+
+
+def test_is_binary_series_detects_two_unique_nonmissing_values(
+    binary_type_df,
+    snapshot,
+):
+    results = {
+        col: _is_binary_series(binary_type_df[col]) for col in binary_type_df.columns
+    }
+
+    assert results == snapshot

--- a/tests/api/test_stats.py
+++ b/tests/api/test_stats.py
@@ -84,6 +84,21 @@ def test_btable_mean_std_suppresses_std_for_binary_variables(
     assert table.df.to_csv().strip() == snapshot
 
 
+def test_btable_accepts_list_group_for_column_combinations(
+    btable_factorial_df,
+    snapshot,
+):
+    pytest.importorskip("pyfixest")
+    table = mt.BTable(
+        btable_factorial_df,
+        vars=["x", "z"],
+        group=["treatment", "period"],
+        stats=["mean"],
+    )
+
+    assert table.df.to_csv().strip() == snapshot
+
+
 def test_is_binary_series_detects_two_unique_nonmissing_values(
     binary_type_df,
     snapshot,

--- a/tests/api/test_stats.py
+++ b/tests/api/test_stats.py
@@ -1,8 +1,9 @@
 """Snapshot tests for ETable model statistics."""
 
-import maketables as mt
 import pytest
 from helpers import OUTPUT_TYPES, render_table
+
+import maketables as mt
 
 
 class TestETableModelStats:

--- a/tests/api/test_stats.py
+++ b/tests/api/test_stats.py
@@ -17,6 +17,11 @@ class TestETableModelStats:
         table = mt.ETable([fitted_model], model_stats=["N", "r2", "adj_r2", "rmse"])
         assert table.make(type="tex") == snapshot
 
+    def test_model_stats_extended_typst(self, fitted_model, snapshot):
+        """Extended statistics including adj_r2 and rmse in Typst."""
+        table = mt.ETable([fitted_model], model_stats=["N", "r2", "adj_r2", "rmse"])
+        assert table.make(type="typst") == snapshot
+
     def test_model_stats_minimal_html(self, fitted_model, snapshot):
         """Minimal statistics (only N)."""
         table = mt.ETable([fitted_model], model_stats=["N"])
@@ -27,6 +32,11 @@ class TestETableModelStats:
         table = mt.ETable([fitted_model], model_stats=["N"])
         assert table.make(type="tex") == snapshot
 
+    def test_model_stats_minimal_typst(self, fitted_model, snapshot):
+        """Minimal statistics (only N) in Typst."""
+        table = mt.ETable([fitted_model], model_stats=["N"])
+        assert table.make(type="typst") == snapshot
+
     def test_model_stats_with_se_type_html(self, fitted_model, snapshot):
         """Include standard error type."""
         table = mt.ETable([fitted_model], model_stats=["N", "r2", "se_type"])
@@ -36,6 +46,11 @@ class TestETableModelStats:
         """Include standard error type."""
         table = mt.ETable([fitted_model], model_stats=["N", "r2", "se_type"])
         assert table.make(type="tex") == snapshot
+
+    def test_model_stats_with_se_type_typst(self, fitted_model, snapshot):
+        """Include standard error type in Typst."""
+        table = mt.ETable([fitted_model], model_stats=["N", "r2", "se_type"])
+        assert table.make(type="typst") == snapshot
 
     def test_model_stats_custom_labels_html(self, fitted_model, snapshot):
         """Custom labels for model statistics."""
@@ -55,6 +70,15 @@ class TestETableModelStats:
         )
         assert table.make(type="tex") == snapshot
 
+    def test_model_stats_custom_labels_typst(self, fitted_model, snapshot):
+        """Custom labels for model statistics in Typst."""
+        table = mt.ETable(
+            [fitted_model],
+            model_stats=["N", "r2"],
+            model_stats_labels={"N": "Sample Size", "r2": "R-squared"},
+        )
+        assert table.make(type="typst") == snapshot
+
     def test_model_stats_aic_bic_html(self, fitted_model, snapshot):
         """Information criteria (AIC, BIC)."""
         table = mt.ETable([fitted_model], model_stats=["N", "aic", "bic"])
@@ -64,3 +88,8 @@ class TestETableModelStats:
         """Information criteria (AIC, BIC)."""
         table = mt.ETable([fitted_model], model_stats=["N", "aic", "bic"])
         assert table.make(type="tex") == snapshot
+
+    def test_model_stats_aic_bic_typst(self, fitted_model, snapshot):
+        """Information criteria (AIC, BIC) in Typst."""
+        table = mt.ETable([fitted_model], model_stats=["N", "aic", "bic"])
+        assert table.make(type="typst") == snapshot

--- a/tests/api/test_stats.py
+++ b/tests/api/test_stats.py
@@ -1,95 +1,40 @@
 """Snapshot tests for ETable model statistics."""
 
 import maketables as mt
-from helpers import normalize_html
+import pytest
+from helpers import OUTPUT_TYPES, render_table
 
 
 class TestETableModelStats:
     """Snapshot tests for model_stats variations."""
 
-    def test_model_stats_extended_html(self, fitted_model, snapshot):
-        """Extended statistics including adj_r2 and rmse."""
-        table = mt.ETable([fitted_model], model_stats=["N", "r2", "adj_r2", "rmse"])
-        assert normalize_html(table.make(type="gt").as_raw_html()) == snapshot
-
-    def test_model_stats_extended_latex(self, fitted_model, snapshot):
-        """Extended statistics including adj_r2 and rmse."""
-        table = mt.ETable([fitted_model], model_stats=["N", "r2", "adj_r2", "rmse"])
-        assert table.make(type="tex") == snapshot
-
-    def test_model_stats_extended_typst(self, fitted_model, snapshot):
-        """Extended statistics including adj_r2 and rmse in Typst."""
-        table = mt.ETable([fitted_model], model_stats=["N", "r2", "adj_r2", "rmse"])
-        assert table.make(type="typst") == snapshot
-
-    def test_model_stats_minimal_html(self, fitted_model, snapshot):
-        """Minimal statistics (only N)."""
-        table = mt.ETable([fitted_model], model_stats=["N"])
-        assert normalize_html(table.make(type="gt").as_raw_html()) == snapshot
-
-    def test_model_stats_minimal_latex(self, fitted_model, snapshot):
-        """Minimal statistics (only N)."""
-        table = mt.ETable([fitted_model], model_stats=["N"])
-        assert table.make(type="tex") == snapshot
-
-    def test_model_stats_minimal_typst(self, fitted_model, snapshot):
-        """Minimal statistics (only N) in Typst."""
-        table = mt.ETable([fitted_model], model_stats=["N"])
-        assert table.make(type="typst") == snapshot
-
-    def test_model_stats_with_se_type_html(self, fitted_model, snapshot):
-        """Include standard error type."""
-        table = mt.ETable([fitted_model], model_stats=["N", "r2", "se_type"])
-        assert normalize_html(table.make(type="gt").as_raw_html()) == snapshot
-
-    def test_model_stats_with_se_type_latex(self, fitted_model, snapshot):
-        """Include standard error type."""
-        table = mt.ETable([fitted_model], model_stats=["N", "r2", "se_type"])
-        assert table.make(type="tex") == snapshot
-
-    def test_model_stats_with_se_type_typst(self, fitted_model, snapshot):
-        """Include standard error type in Typst."""
-        table = mt.ETable([fitted_model], model_stats=["N", "r2", "se_type"])
-        assert table.make(type="typst") == snapshot
-
-    def test_model_stats_custom_labels_html(self, fitted_model, snapshot):
-        """Custom labels for model statistics."""
+    @pytest.mark.parametrize("output_type", OUTPUT_TYPES)
+    @pytest.mark.parametrize(
+        "model_stats, model_stats_labels",
+        [
+            pytest.param(["N", "r2", "adj_r2", "rmse"], None, id="extended"),
+            pytest.param(["N"], None, id="minimal"),
+            pytest.param(["N", "r2", "se_type"], None, id="with_se_type"),
+            pytest.param(
+                ["N", "r2"],
+                {"N": "Sample Size", "r2": "R-squared"},
+                id="custom_labels",
+            ),
+            pytest.param(["N", "aic", "bic"], None, id="aic_bic"),
+        ],
+    )
+    def test_model_stats(
+        self,
+        fitted_model,
+        snapshot,
+        model_stats,
+        model_stats_labels,
+        output_type,
+    ):
+        """Model statistics variations."""
         table = mt.ETable(
             [fitted_model],
-            model_stats=["N", "r2"],
-            model_stats_labels={"N": "Sample Size", "r2": "R-squared"},
+            model_stats=model_stats,
+            model_stats_labels=model_stats_labels,
         )
-        assert normalize_html(table.make(type="gt").as_raw_html()) == snapshot
-
-    def test_model_stats_custom_labels_latex(self, fitted_model, snapshot):
-        """Custom labels for model statistics."""
-        table = mt.ETable(
-            [fitted_model],
-            model_stats=["N", "r2"],
-            model_stats_labels={"N": "Sample Size", "r2": "R-squared"},
-        )
-        assert table.make(type="tex") == snapshot
-
-    def test_model_stats_custom_labels_typst(self, fitted_model, snapshot):
-        """Custom labels for model statistics in Typst."""
-        table = mt.ETable(
-            [fitted_model],
-            model_stats=["N", "r2"],
-            model_stats_labels={"N": "Sample Size", "r2": "R-squared"},
-        )
-        assert table.make(type="typst") == snapshot
-
-    def test_model_stats_aic_bic_html(self, fitted_model, snapshot):
-        """Information criteria (AIC, BIC)."""
-        table = mt.ETable([fitted_model], model_stats=["N", "aic", "bic"])
-        assert normalize_html(table.make(type="gt").as_raw_html()) == snapshot
-
-    def test_model_stats_aic_bic_latex(self, fitted_model, snapshot):
-        """Information criteria (AIC, BIC)."""
-        table = mt.ETable([fitted_model], model_stats=["N", "aic", "bic"])
-        assert table.make(type="tex") == snapshot
-
-    def test_model_stats_aic_bic_typst(self, fitted_model, snapshot):
-        """Information criteria (AIC, BIC) in Typst."""
-        table = mt.ETable([fitted_model], model_stats=["N", "aic", "bic"])
-        assert table.make(type="typst") == snapshot
+        assert render_table(table, output_type) == snapshot

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,53 @@ def dtable_binary_df():
 
 
 @pytest.fixture
+def btable_factorial_df():
+    """Create 2x2 grouped data for BTable tests."""
+    return pd.DataFrame(
+        {
+            "x": [
+                1.0,
+                1.2,
+                2.0,
+                2.2,
+                3.0,
+                3.2,
+                4.0,
+                4.2,
+                1.5,
+                1.7,
+                2.5,
+                2.7,
+                3.5,
+                3.7,
+                4.5,
+                4.7,
+            ],
+            "z": [
+                2.0,
+                2.2,
+                2.5,
+                2.7,
+                3.5,
+                3.7,
+                4.0,
+                4.2,
+                2.1,
+                2.3,
+                2.6,
+                2.8,
+                3.6,
+                3.8,
+                4.1,
+                4.3,
+            ],
+            "treatment": ["control"] * 8 + ["treated"] * 8,
+            "period": ["pre", "pre", "post", "post"] * 4,
+        }
+    )
+
+
+@pytest.fixture
 def binary_type_df():
     """Create binary and non-binary columns across several dtypes."""
     return pd.DataFrame(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,11 +10,13 @@ def simple_df():
     """Simple DataFrame for basic table tests."""
     np.random.seed(42)
     n = 100
-    return pd.DataFrame({
-        "x": np.random.randn(n),
-        "y": np.random.randn(n),
-        "group": np.random.choice(["A", "B"], n),
-    })
+    return pd.DataFrame(
+        {
+            "x": np.random.randn(n),
+            "y": np.random.randn(n),
+            "group": np.random.choice(["A", "B"], n),
+        }
+    )
 
 
 @pytest.fixture
@@ -23,10 +25,12 @@ def fitted_model(simple_df):
     import pyfixest as pf
 
     # Create fully deterministic data (no random component)
-    df = pd.DataFrame({
-        "x": [1.0, 2.0, 3.0, 4.0, 5.0] * 20,  # 100 rows
-        "y": [2.1, 4.1, 6.1, 8.1, 10.1] * 20,  # Deterministic: y ≈ 2*x + 0.1
-    })
+    df = pd.DataFrame(
+        {
+            "x": [1.0, 2.0, 3.0, 4.0, 5.0] * 20,  # 100 rows
+            "y": [2.1, 4.1, 6.1, 8.1, 10.1] * 20,  # Deterministic: y ≈ 2*x + 0.1
+        }
+    )
     return pf.feols("y ~ x", data=df)
 
 
@@ -116,12 +120,14 @@ def panel_df():
     time_effects = np.random.randn(n_periods)
 
     # Create panel data
-    df = pd.DataFrame({
-        "entity": entity_id,
-        "time": time_id,
-        "x1": np.random.randn(n_obs),
-        "x2": np.random.randn(n_obs),
-    })
+    df = pd.DataFrame(
+        {
+            "entity": entity_id,
+            "time": time_id,
+            "x1": np.random.randn(n_obs),
+            "x2": np.random.randn(n_obs),
+        }
+    )
 
     # Create outcome with entity effects
     df["y"] = (
@@ -168,13 +174,20 @@ def linearmodels_absorbingls():
     firm_id = np.random.choice(n_firms, size=n_obs)
     firm_effects = np.random.randn(n_firms)
 
-    df = pd.DataFrame({
-        "firm_id": firm_id,
-        "x1": np.random.randn(n_obs),
-        "x2": np.random.randn(n_obs),
-    })
+    df = pd.DataFrame(
+        {
+            "firm_id": firm_id,
+            "x1": np.random.randn(n_obs),
+            "x2": np.random.randn(n_obs),
+        }
+    )
 
-    df["y"] = 2 * df["x1"] + 0.5 * df["x2"] + firm_effects[firm_id] + np.random.randn(n_obs) * 0.1
+    df["y"] = (
+        2 * df["x1"]
+        + 0.5 * df["x2"]
+        + firm_effects[firm_id]
+        + np.random.randn(n_obs) * 0.1
+    )
 
     # Fit AbsorbingLS
     mod = AbsorbingLS(
@@ -199,12 +212,14 @@ def linearmodels_iv2sls():
     x_exog = np.random.randn(n_obs)  # Exogenous regressor
     y = 2 * x_endog + 0.5 * x_exog + np.random.randn(n_obs) * 0.1
 
-    df = pd.DataFrame({
-        "y": y,
-        "x_endog": x_endog,
-        "x_exog": x_exog,
-        "z": z,
-    })
+    df = pd.DataFrame(
+        {
+            "y": y,
+            "x_endog": x_endog,
+            "x_exog": x_exog,
+            "z": z,
+        }
+    )
 
     # IV2SLS: y ~ x_exog + [x_endog ~ z]
     mod = IV2SLS.from_formula("y ~ 1 + x_exog + [x_endog ~ z]", data=df)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import pytest
 
 @pytest.fixture
 def simple_df():
-    """Simple DataFrame for basic table tests."""
+    """Create a simple DataFrame for basic table tests."""
     np.random.seed(42)
     n = 100
     return pd.DataFrame(
@@ -20,8 +20,47 @@ def simple_df():
 
 
 @pytest.fixture
+def dtable_binary_df():
+    """Create data with binary and continuous variables for DTable/BTable tests."""
+    return pd.DataFrame(
+        {
+            "binary": [0, 1, 1, 0, 0, 1, 1, 0],
+            "continuous": [1.0, 2.0, 4.0, 5.0, 1.5, 2.5, 4.5, 5.5],
+            "group": ["A", "A", "B", "B", "A", "A", "B", "B"],
+        }
+    )
+
+
+@pytest.fixture
+def binary_type_df():
+    """Create binary and non-binary columns across several dtypes."""
+    return pd.DataFrame(
+        {
+            "int_binary": [0, 1, 1, 0],
+            "non_indicator_numeric_binary": [1, 2, np.nan, 2],
+            "float_binary": [0.0, 1.0, np.nan, 1.0],
+            "bool_binary": [True, False, True, False],
+            "nullable_bool_binary": pd.Series(
+                [True, False, pd.NA, True],
+                dtype="boolean",
+            ),
+            "string_binary": ["yes", "no", None, "yes"],
+            "categorical_binary": pd.Categorical(
+                ["treated", "control", None, "treated"],
+            ),
+            "datetime_binary": pd.to_datetime(
+                ["2020-01-01", "2020-01-02", None, "2020-01-01"],
+            ),
+            "single_level": [1, 1, np.nan, 1],
+            "three_level": ["a", "b", "c", None],
+            "all_missing": [None, None, None, None],
+        }
+    )
+
+
+@pytest.fixture
 def fitted_model(simple_df):
-    """Single fitted pyfixest model."""
+    """Create a single fitted pyfixest model."""
     import pyfixest as pf
 
     # Create fully deterministic data (no random component)
@@ -36,7 +75,7 @@ def fitted_model(simple_df):
 
 @pytest.fixture
 def fitted_models(simple_df):
-    """Multiple fitted pyfixest models for multi-column tables."""
+    """Create multiple fitted pyfixest models for multi-column tables."""
     import pyfixest as pf
 
     np.random.seed(42)
@@ -51,7 +90,7 @@ def fitted_models(simple_df):
 
 @pytest.fixture
 def fitted_model_fe(simple_df):
-    """Pyfixest model with fixed effects."""
+    """Create a pyfixest model with fixed effects."""
     import pyfixest as pf
 
     np.random.seed(42)
@@ -67,7 +106,7 @@ def fitted_model_fe(simple_df):
 
 @pytest.fixture
 def statsmodels_ols(simple_df):
-    """Statsmodels OLS model."""
+    """Create a statsmodels OLS model."""
     import statsmodels.formula.api as smf
 
     np.random.seed(42)
@@ -78,7 +117,7 @@ def statsmodels_ols(simple_df):
 
 @pytest.fixture
 def statsmodels_logit(simple_df):
-    """Statsmodels Logit model."""
+    """Create a statsmodels Logit model."""
     import statsmodels.formula.api as smf
 
     np.random.seed(42)
@@ -90,7 +129,7 @@ def statsmodels_logit(simple_df):
 
 @pytest.fixture
 def statsmodels_probit(simple_df):
-    """Statsmodels Probit model."""
+    """Create a statsmodels Probit model."""
     import statsmodels.formula.api as smf
 
     np.random.seed(42)
@@ -105,7 +144,7 @@ def statsmodels_probit(simple_df):
 
 @pytest.fixture
 def panel_df():
-    """Panel DataFrame for linearmodels tests."""
+    """Create a panel DataFrame for linearmodels tests."""
     np.random.seed(42)
     n_entities = 20
     n_periods = 5
@@ -145,7 +184,7 @@ def panel_df():
 
 @pytest.fixture
 def linearmodels_panelols(panel_df):
-    """Linearmodels PanelOLS with entity effects."""
+    """Create a linearmodels PanelOLS with entity effects."""
     from linearmodels import PanelOLS
 
     mod = PanelOLS.from_formula("y ~ x1 + x2 + EntityEffects", data=panel_df)
@@ -154,7 +193,7 @@ def linearmodels_panelols(panel_df):
 
 @pytest.fixture
 def linearmodels_pooledols(panel_df):
-    """Linearmodels PooledOLS (no fixed effects)."""
+    """Create a linearmodels PooledOLS without fixed effects."""
     from linearmodels import PooledOLS
 
     mod = PooledOLS.from_formula("y ~ x1 + x2", data=panel_df)
@@ -163,7 +202,7 @@ def linearmodels_pooledols(panel_df):
 
 @pytest.fixture
 def linearmodels_absorbingls():
-    """Linearmodels AbsorbingLS with high-dimensional fixed effects."""
+    """Create a linearmodels AbsorbingLS with high-dimensional fixed effects."""
     from linearmodels import AbsorbingLS
 
     np.random.seed(42)
@@ -200,7 +239,7 @@ def linearmodels_absorbingls():
 
 @pytest.fixture
 def linearmodels_iv2sls():
-    """Linearmodels IV2SLS with instrumental variables."""
+    """Create a linearmodels IV2SLS with instrumental variables."""
     from linearmodels.iv import IV2SLS
 
     np.random.seed(42)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,9 +2,26 @@
 
 import re
 
+import pytest
+
+
+OUTPUT_TYPES = [
+    pytest.param("gt", id="html"),
+    pytest.param("tex", id="latex"),
+    pytest.param("typst", id="typst"),
+]
+
 
 def normalize_html(html: str) -> str:
     """Normalize HTML output by replacing random IDs with a stable placeholder."""
     normalized = re.sub(r'id="([a-z]{10})"', 'id="STABLE_ID"', html)
     normalized = re.sub(r"#[a-z]{10}", "#STABLE_ID", normalized)
     return normalized
+
+
+def render_table(table, output_type: str) -> str:
+    """Render a table and normalize HTML snapshots."""
+    rendered = table.make(type=output_type)
+    if output_type == "gt":
+        return normalize_html(rendered.as_raw_html())
+    return rendered

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -4,7 +4,6 @@ import re
 
 import pytest
 
-
 OUTPUT_TYPES = [
     pytest.param("gt", id="html"),
     pytest.param("tex", id="latex"),

--- a/tests/models/__snapshots__/test_linearmodels.ambr
+++ b/tests/models/__snapshots__/test_linearmodels.ambr
@@ -8,7 +8,7 @@
             -webkit-font-smoothing: antialiased;
             -moz-osx-font-smoothing: grayscale;
           }
-  
+
   #STABLE_ID thead, tbody, tfoot, tr, td, th { border-style: none; }
    tr { background-color: transparent; }
   #STABLE_ID p { margin: 0; padding: 0; }
@@ -47,11 +47,11 @@
    #STABLE_ID .gt_super { font-size: 65%; }
    #STABLE_ID .gt_footnote_marks { font-size: 75%; vertical-align: 0.4em; position: initial; }
    #STABLE_ID .gt_asterisk { font-size: 100%; vertical-align: 0; }
-   
+
   </style>
   <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>
-  
+
   <tr class="gt_col_headings gt_spanner_row">
     <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="2" colspan="1" scope="col" id=""></th>
     <th class="gt_center gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="1" scope="col" id="y">
@@ -94,17 +94,17 @@
     </tr>
   </tbody>
     <tfoot class="gt_sourcenotes">
-    
+
     <tr>
       <td class="gt_sourcenote" colspan="2">Significance levels: * p &lt; 0.1, ** p &lt; 0.05, *** p &lt; 0.01. Format of coefficient cell: Coefficient   (Std. Error)</td>
     </tr>
-  
+
   </tfoot>
-  
+
   </table>
-  
+
   </div>
-          
+
   '''
 # ---
 # name: TestLinearmodels.test_model[absorbingls-latex]
@@ -142,7 +142,7 @@
   \endgroup
   \noindent\begin{minipage}{\linewidth}\smallskip\footnotesize
   Significance levels: * p < 0.1, ** p < 0.05, *** p < 0.01. Format of coefficient cell: Coefficient   (Std. Error)\end{minipage}
-  
+
   \end{threeparttable}
   '''
 # ---
@@ -181,7 +181,7 @@
             -webkit-font-smoothing: antialiased;
             -moz-osx-font-smoothing: grayscale;
           }
-  
+
   #STABLE_ID thead, tbody, tfoot, tr, td, th { border-style: none; }
    tr { background-color: transparent; }
   #STABLE_ID p { margin: 0; padding: 0; }
@@ -220,11 +220,11 @@
    #STABLE_ID .gt_super { font-size: 65%; }
    #STABLE_ID .gt_footnote_marks { font-size: 75%; vertical-align: 0.4em; position: initial; }
    #STABLE_ID .gt_asterisk { font-size: 100%; vertical-align: 0; }
-   
+
   </style>
   <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>
-  
+
   <tr class="gt_col_headings gt_spanner_row">
     <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="2" colspan="1" scope="col" id=""></th>
     <th class="gt_center gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="1" scope="col" id="y">
@@ -264,17 +264,17 @@
     </tr>
   </tbody>
     <tfoot class="gt_sourcenotes">
-    
+
     <tr>
       <td class="gt_sourcenote" colspan="2">Significance levels: * p &lt; 0.1, ** p &lt; 0.05, *** p &lt; 0.01. Format of coefficient cell: Coefficient   (Std. Error)</td>
     </tr>
-  
+
   </tfoot>
-  
+
   </table>
-  
+
   </div>
-          
+
   '''
 # ---
 # name: TestLinearmodels.test_model[iv2sls-latex]
@@ -311,7 +311,7 @@
   \endgroup
   \noindent\begin{minipage}{\linewidth}\smallskip\footnotesize
   Significance levels: * p < 0.1, ** p < 0.05, *** p < 0.01. Format of coefficient cell: Coefficient   (Std. Error)\end{minipage}
-  
+
   \end{threeparttable}
   '''
 # ---
@@ -348,7 +348,7 @@
             -webkit-font-smoothing: antialiased;
             -moz-osx-font-smoothing: grayscale;
           }
-  
+
   #STABLE_ID thead, tbody, tfoot, tr, td, th { border-style: none; }
    tr { background-color: transparent; }
   #STABLE_ID p { margin: 0; padding: 0; }
@@ -387,11 +387,11 @@
    #STABLE_ID .gt_super { font-size: 65%; }
    #STABLE_ID .gt_footnote_marks { font-size: 75%; vertical-align: 0.4em; position: initial; }
    #STABLE_ID .gt_asterisk { font-size: 100%; vertical-align: 0; }
-   
+
   </style>
   <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>
-  
+
   <tr class="gt_col_headings gt_spanner_row">
     <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="2" colspan="1" scope="col" id=""></th>
     <th class="gt_center gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="1" scope="col" id="y">
@@ -434,17 +434,17 @@
     </tr>
   </tbody>
     <tfoot class="gt_sourcenotes">
-    
+
     <tr>
       <td class="gt_sourcenote" colspan="2">Significance levels: * p &lt; 0.1, ** p &lt; 0.05, *** p &lt; 0.01. Format of coefficient cell: Coefficient   (Std. Error)</td>
     </tr>
-  
+
   </tfoot>
-  
+
   </table>
-  
+
   </div>
-          
+
   '''
 # ---
 # name: TestLinearmodels.test_model[panelols-latex]
@@ -482,7 +482,7 @@
   \endgroup
   \noindent\begin{minipage}{\linewidth}\smallskip\footnotesize
   Significance levels: * p < 0.1, ** p < 0.05, *** p < 0.01. Format of coefficient cell: Coefficient   (Std. Error)\end{minipage}
-  
+
   \end{threeparttable}
   '''
 # ---
@@ -521,7 +521,7 @@
             -webkit-font-smoothing: antialiased;
             -moz-osx-font-smoothing: grayscale;
           }
-  
+
   #STABLE_ID thead, tbody, tfoot, tr, td, th { border-style: none; }
    tr { background-color: transparent; }
   #STABLE_ID p { margin: 0; padding: 0; }
@@ -560,11 +560,11 @@
    #STABLE_ID .gt_super { font-size: 65%; }
    #STABLE_ID .gt_footnote_marks { font-size: 75%; vertical-align: 0.4em; position: initial; }
    #STABLE_ID .gt_asterisk { font-size: 100%; vertical-align: 0; }
-   
+
   </style>
   <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>
-  
+
   <tr class="gt_col_headings gt_spanner_row">
     <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="2" colspan="1" scope="col" id=""></th>
     <th class="gt_center gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="1" scope="col" id="y">
@@ -600,17 +600,17 @@
     </tr>
   </tbody>
     <tfoot class="gt_sourcenotes">
-    
+
     <tr>
       <td class="gt_sourcenote" colspan="2">Significance levels: * p &lt; 0.1, ** p &lt; 0.05, *** p &lt; 0.01. Format of coefficient cell: Coefficient   (Std. Error)</td>
     </tr>
-  
+
   </tfoot>
-  
+
   </table>
-  
+
   </div>
-          
+
   '''
 # ---
 # name: TestLinearmodels.test_model[pooledols-latex]
@@ -644,7 +644,7 @@
   \endgroup
   \noindent\begin{minipage}{\linewidth}\smallskip\footnotesize
   Significance levels: * p < 0.1, ** p < 0.05, *** p < 0.01. Format of coefficient cell: Coefficient   (Std. Error)\end{minipage}
-  
+
   \end{threeparttable}
   '''
 # ---

--- a/tests/models/__snapshots__/test_linearmodels.ambr
+++ b/tests/models/__snapshots__/test_linearmodels.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: TestLinearmodels.test_absorbingls_html
+# name: TestLinearmodels.test_model[absorbingls-html]
   '''
   <div id="STABLE_ID" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
   <style>
@@ -107,7 +107,7 @@
           
   '''
 # ---
-# name: TestLinearmodels.test_absorbingls_latex
+# name: TestLinearmodels.test_model[absorbingls-latex]
   '''
   \begin{threeparttable}
   \begingroup
@@ -146,7 +146,7 @@
   \end{threeparttable}
   '''
 # ---
-# name: TestLinearmodels.test_absorbingls_typst
+# name: TestLinearmodels.test_model[absorbingls-typst]
   '''
   #table(
     columns: (auto, 1fr), align: (left, center),
@@ -172,7 +172,7 @@
   )
   '''
 # ---
-# name: TestLinearmodels.test_iv2sls_html
+# name: TestLinearmodels.test_model[iv2sls-html]
   '''
   <div id="STABLE_ID" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
   <style>
@@ -277,7 +277,7 @@
           
   '''
 # ---
-# name: TestLinearmodels.test_iv2sls_latex
+# name: TestLinearmodels.test_model[iv2sls-latex]
   '''
   \begin{threeparttable}
   \begingroup
@@ -315,7 +315,7 @@
   \end{threeparttable}
   '''
 # ---
-# name: TestLinearmodels.test_iv2sls_typst
+# name: TestLinearmodels.test_model[iv2sls-typst]
   '''
   #table(
     columns: (auto, 1fr), align: (left, center),
@@ -339,7 +339,7 @@
   )
   '''
 # ---
-# name: TestLinearmodels.test_panelols_html
+# name: TestLinearmodels.test_model[panelols-html]
   '''
   <div id="STABLE_ID" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
   <style>
@@ -447,7 +447,7 @@
           
   '''
 # ---
-# name: TestLinearmodels.test_panelols_latex
+# name: TestLinearmodels.test_model[panelols-latex]
   '''
   \begin{threeparttable}
   \begingroup
@@ -486,7 +486,7 @@
   \end{threeparttable}
   '''
 # ---
-# name: TestLinearmodels.test_panelols_typst
+# name: TestLinearmodels.test_model[panelols-typst]
   '''
   #table(
     columns: (auto, 1fr), align: (left, center),
@@ -512,7 +512,7 @@
   )
   '''
 # ---
-# name: TestLinearmodels.test_pooledols_html
+# name: TestLinearmodels.test_model[pooledols-html]
   '''
   <div id="STABLE_ID" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
   <style>
@@ -613,7 +613,7 @@
           
   '''
 # ---
-# name: TestLinearmodels.test_pooledols_latex
+# name: TestLinearmodels.test_model[pooledols-latex]
   '''
   \begin{threeparttable}
   \begingroup
@@ -648,7 +648,7 @@
   \end{threeparttable}
   '''
 # ---
-# name: TestLinearmodels.test_pooledols_typst
+# name: TestLinearmodels.test_model[pooledols-typst]
   '''
   #table(
     columns: (auto, 1fr), align: (left, center),

--- a/tests/models/__snapshots__/test_linearmodels.ambr
+++ b/tests/models/__snapshots__/test_linearmodels.ambr
@@ -146,6 +146,32 @@
   \end{threeparttable}
   '''
 # ---
+# name: TestLinearmodels.test_absorbingls_typst
+  '''
+  #table(
+    columns: (auto, 1fr), align: (left, center),
+    column-gutter: (0em),
+    stroke: none, row-gutter: 0.2em,
+    table.hline(stroke: 0.08em),
+    [], [#table.cell(colspan: 1)[y]],
+    table.hline(stroke: 0.03em, start: 1, end: 2),
+    [], [(1)],
+    table.hline(stroke: 0.05em),
+    table.hline(stroke: 0.03em),
+    [x1], [2.004\*\*\* \ (0.068)],
+    [x2], [0.570\*\*\* \ (0.069)],
+    table.hline(stroke: 0.03em),
+    table.hline(stroke: 0.03em),
+    [firm\_id], [x],
+    table.hline(stroke: 0.03em),
+    table.hline(stroke: 0.03em),
+    [Observations], [200],
+    [$R^2$], [0.813],
+    table.hline(stroke: 0.08em),
+    [#table.cell(colspan: 2)[#text(size: 10pt)[Significance levels: \* p \< 0.1, \*\* p \< 0.05, \*\*\* p \< 0.01. Format of coefficient cell: Coefficient   (Std. Error)]]],
+  )
+  '''
+# ---
 # name: TestLinearmodels.test_iv2sls_html
   '''
   <div id="STABLE_ID" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
@@ -287,6 +313,30 @@
   Significance levels: * p < 0.1, ** p < 0.05, *** p < 0.01. Format of coefficient cell: Coefficient   (Std. Error)\end{minipage}
   
   \end{threeparttable}
+  '''
+# ---
+# name: TestLinearmodels.test_iv2sls_typst
+  '''
+  #table(
+    columns: (auto, 1fr), align: (left, center),
+    column-gutter: (0em),
+    stroke: none, row-gutter: 0.2em,
+    table.hline(stroke: 0.08em),
+    [], [#table.cell(colspan: 1)[y]],
+    table.hline(stroke: 0.03em, start: 1, end: 2),
+    [], [(1)],
+    table.hline(stroke: 0.05em),
+    table.hline(stroke: 0.03em),
+    [x\_exog], [0.512\*\*\* \ (0.006)],
+    [x\_endog], [2.016\*\*\* \ (0.014)],
+    [Intercept], [0.002 \ (0.007)],
+    table.hline(stroke: 0.03em),
+    table.hline(stroke: 0.03em),
+    [Observations], [200],
+    [$R^2$], [0.995],
+    table.hline(stroke: 0.08em),
+    [#table.cell(colspan: 2)[#text(size: 10pt)[Significance levels: \* p \< 0.1, \*\* p \< 0.05, \*\*\* p \< 0.01. Format of coefficient cell: Coefficient   (Std. Error)]]],
+  )
   '''
 # ---
 # name: TestLinearmodels.test_panelols_html
@@ -436,6 +486,32 @@
   \end{threeparttable}
   '''
 # ---
+# name: TestLinearmodels.test_panelols_typst
+  '''
+  #table(
+    columns: (auto, 1fr), align: (left, center),
+    column-gutter: (0em),
+    stroke: none, row-gutter: 0.2em,
+    table.hline(stroke: 0.08em),
+    [], [#table.cell(colspan: 1)[y]],
+    table.hline(stroke: 0.03em, start: 1, end: 2),
+    [], [(1)],
+    table.hline(stroke: 0.05em),
+    table.hline(stroke: 0.03em),
+    [x1], [1.998\*\*\* \ (0.112)],
+    [x2], [0.623\*\*\* \ (0.110)],
+    table.hline(stroke: 0.03em),
+    table.hline(stroke: 0.03em),
+    [entity], [x],
+    table.hline(stroke: 0.03em),
+    table.hline(stroke: 0.03em),
+    [Observations], [100],
+    [$R^2$], [0.791],
+    table.hline(stroke: 0.08em),
+    [#table.cell(colspan: 2)[#text(size: 10pt)[Significance levels: \* p \< 0.1, \*\* p \< 0.05, \*\*\* p \< 0.01. Format of coefficient cell: Coefficient   (Std. Error)]]],
+  )
+  '''
+# ---
 # name: TestLinearmodels.test_pooledols_html
   '''
   <div id="STABLE_ID" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
@@ -570,5 +646,28 @@
   Significance levels: * p < 0.1, ** p < 0.05, *** p < 0.01. Format of coefficient cell: Coefficient   (Std. Error)\end{minipage}
   
   \end{threeparttable}
+  '''
+# ---
+# name: TestLinearmodels.test_pooledols_typst
+  '''
+  #table(
+    columns: (auto, 1fr), align: (left, center),
+    column-gutter: (0em),
+    stroke: none, row-gutter: 0.2em,
+    table.hline(stroke: 0.08em),
+    [], [#table.cell(colspan: 1)[y]],
+    table.hline(stroke: 0.03em, start: 1, end: 2),
+    [], [(1)],
+    table.hline(stroke: 0.05em),
+    table.hline(stroke: 0.03em),
+    [x1], [1.957\*\*\* \ (0.128)],
+    [x2], [0.600\*\*\* \ (0.144)],
+    table.hline(stroke: 0.03em),
+    table.hline(stroke: 0.03em),
+    [Observations], [100],
+    [$R^2$], [0.665],
+    table.hline(stroke: 0.08em),
+    [#table.cell(colspan: 2)[#text(size: 10pt)[Significance levels: \* p \< 0.1, \*\* p \< 0.05, \*\*\* p \< 0.01. Format of coefficient cell: Coefficient   (Std. Error)]]],
+  )
   '''
 # ---

--- a/tests/models/__snapshots__/test_pyfixest.ambr
+++ b/tests/models/__snapshots__/test_pyfixest.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: TestPyfixest.test_fixed_effects_html
+# name: TestPyfixest.test_model[fixed_effects-html]
   '''
   <div id="STABLE_ID" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
   <style>
@@ -103,7 +103,7 @@
           
   '''
 # ---
-# name: TestPyfixest.test_fixed_effects_latex
+# name: TestPyfixest.test_model[fixed_effects-latex]
   '''
   \begin{threeparttable}
   \begingroup
@@ -139,7 +139,7 @@
   \end{threeparttable}
   '''
 # ---
-# name: TestPyfixest.test_fixed_effects_typst
+# name: TestPyfixest.test_model[fixed_effects-typst]
   '''
   #table(
     columns: (auto, 1fr), align: (left, center),
@@ -164,7 +164,339 @@
   )
   '''
 # ---
-# name: TestPyfixest.test_multi_fixest_with_stepwise_html
+# name: TestPyfixest.test_model[multi_model-html]
+  '''
+  <div id="STABLE_ID" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
+  <style>
+  #STABLE_ID table {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', 'Fira Sans', 'Droid Sans', Arial, sans-serif;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+          }
+  
+  #STABLE_ID thead, tbody, tfoot, tr, td, th { border-style: none; }
+   tr { background-color: transparent; }
+  #STABLE_ID p { margin: 0; padding: 0; }
+   #STABLE_ID .gt_table { display: table; border-collapse: collapse; line-height: normal; margin-left: auto; margin-right: auto; color: #333333; font-size: 16px; font-weight: normal; font-style: normal; background-color: #FFFFFF; width: auto; border-top-style: solid; border-top-width: 2px; border-top-color: #A8A8A8; border-right-style: none; border-right-width: 2px; border-right-color: #D3D3D3; border-bottom-style: hidden; border-bottom-width: 2px; border-bottom-color: #A8A8A8; border-left-style: none; border-left-width: 2px; border-left-color: #D3D3D3; }
+   #STABLE_ID .gt_caption { padding-top: 4px; padding-bottom: 4px; }
+   #STABLE_ID .gt_title { color: #333333; font-size: 16px; font-weight: initial; padding-top: 6px; padding-bottom: 6px; padding-left: 5px; padding-right: 5px; border-bottom-color: #FFFFFF; border-bottom-width: 0; }
+   #STABLE_ID .gt_subtitle { color: #333333; font-size: 85%; font-weight: initial; padding-top: 5px; padding-bottom: 7px; padding-left: 5px; padding-right: 5px; border-top-color: #FFFFFF; border-top-width: 0; }
+   #STABLE_ID .gt_heading { background-color: #FFFFFF; text-align: center; border-bottom-color: #FFFFFF; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; }
+   #STABLE_ID .gt_bottom_border { border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; }
+   #STABLE_ID .gt_col_headings { border-top-style: solid; border-top-width: 2px; border-top-color: black; border-bottom-style: solid; border-bottom-width: 0.25px; border-bottom-color: black; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; }
+   #STABLE_ID .gt_col_heading { color: #333333; background-color: #FFFFFF; font-size: 16px; font-weight: normal; text-transform: inherit; border-left-style: none; border-left-width: 0px; border-left-color: white; border-right-style: none; border-right-width: 0px; border-right-color: white; vertical-align: bottom; padding-top: 2px; padding-bottom: 7px; padding-left: 5px; padding-right: 5px; overflow-x: hidden; }
+   #STABLE_ID .gt_column_spanner_outer { color: #333333; background-color: #FFFFFF; font-size: 16px; font-weight: normal; text-transform: inherit; padding-top: 0; padding-bottom: 0; padding-left: 4px; padding-right: 4px; }
+   #STABLE_ID .gt_column_spanner_outer:first-child { padding-left: 0; }
+   #STABLE_ID .gt_column_spanner_outer:last-child { padding-right: 0; }
+   #STABLE_ID .gt_column_spanner { border-bottom-style: solid; border-bottom-width: 0.25px; border-bottom-color: black; vertical-align: bottom; padding-top: 2px; padding-bottom: 2px; overflow-x: hidden; display: inline-block; width: 100%; }
+   #STABLE_ID .gt_spanner_row { border-bottom-style: hidden; }
+   #STABLE_ID .gt_group_heading { padding-top: 0px; padding-bottom: 0px; padding-left: 5px; padding-right: 5px; color: #333333; background-color: #FFFFFF; font-size: 0px; font-weight: initial; text-transform: inherit; border-top-style: solid; border-top-width: 0.25px; border-top-color: black; border-bottom-style: solid; border-bottom-width: 0.25px; border-bottom-color: black; border-left-style: none; border-left-width: 1px; border-left-color: white; border-right-style: none; border-right-width: 1px; border-right-color: white; vertical-align: middle; text-align: left; }
+   #STABLE_ID .gt_empty_group_heading { padding: 0.5px; color: #333333; background-color: #FFFFFF; font-size: 0px; font-weight: initial; border-top-style: solid; border-top-width: 0.25px; border-top-color: black; border-bottom-style: solid; border-bottom-width: 0.25px; border-bottom-color: black; vertical-align: middle; }
+   #STABLE_ID .gt_from_md> :first-child { margin-top: 0; }
+   #STABLE_ID .gt_from_md> :last-child { margin-bottom: 0; }
+   #STABLE_ID .gt_row { padding-top: 2px; padding-bottom: 2px; padding-left: 5px; padding-right: 5px; margin: 10px; border-top-style: none; border-top-width: 1px; border-top-color: #D3D3D3; border-left-style: none; border-left-width: 0px; border-left-color: white; border-right-style: none; border-right-width: 0px; border-right-color: white; vertical-align: middle; overflow-x: hidden; }
+   #STABLE_ID .gt_stub { color: #333333; background-color: #FFFFFF; font-size: 16px; font-weight: initial; text-transform: inherit; border-right-style: hidden; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 5px; padding-right: 5px; }
+   #STABLE_ID .gt_stub_row_group { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 5px; padding-right: 5px; vertical-align: top; }
+   #STABLE_ID .gt_row_group_first td { border-top-width: 0.25px; }
+   #STABLE_ID .gt_row_group_first th { border-top-width: 0.25px; }
+   #STABLE_ID .gt_striped { background-color: rgba(128,128,128,0.05); }
+   #STABLE_ID .gt_table_body { border-top-style: solid; border-top-width: 0px; border-top-color: black; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: black; }
+   #STABLE_ID .gt_sourcenotes { color: #333333; background-color: #FFFFFF; border-bottom-style: none; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 2px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 2px; border-right-color: #D3D3D3; }
+   #STABLE_ID .gt_sourcenote { font-size: 10px; padding-top: 4px; padding-bottom: 4px; padding-left: 5px; padding-right: 5px; text-align: left; }
+   #STABLE_ID .gt_left { text-align: left; }
+   #STABLE_ID .gt_center { text-align: center; }
+   #STABLE_ID .gt_right { text-align: right; font-variant-numeric: tabular-nums; }
+   #STABLE_ID .gt_font_normal { font-weight: normal; }
+   #STABLE_ID .gt_font_bold { font-weight: bold; }
+   #STABLE_ID .gt_font_italic { font-style: italic; }
+   #STABLE_ID .gt_super { font-size: 65%; }
+   #STABLE_ID .gt_footnote_marks { font-size: 75%; vertical-align: 0.4em; position: initial; }
+   #STABLE_ID .gt_asterisk { font-size: 100%; vertical-align: 0; }
+   
+  </style>
+  <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
+  <thead>
+  
+  <tr class="gt_col_headings gt_spanner_row">
+    <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="2" colspan="1" scope="col" id=""></th>
+    <th class="gt_center gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="2" scope="colgroup" id="y">
+      <span class="gt_column_spanner">y</span>
+    </th>
+  </tr>
+  <tr class="gt_col_headings">
+    <th class="gt_col_heading gt_columns_bottom_border gt_center" rowspan="1" colspan="1" scope="col" id="0">(1)</th>
+    <th class="gt_col_heading gt_columns_bottom_border gt_center" rowspan="1" colspan="1" scope="col" id="1">(2)</th>
+  </tr>
+  </thead>
+  <tbody class="gt_table_body">
+    <tr class="gt_group_heading_row">
+      <th class="gt_group_heading" colspan="3">coef</th>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub">x</th>
+      <td class="gt_row gt_center">2.100*** <br> (0.000)</td>
+      <td class="gt_row gt_center">2.100*** <br> (0.000)</td>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub">group=B</th>
+      <td class="gt_row gt_center"></td>
+      <td class="gt_row gt_center">-0.000 <br> (0.000)</td>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub">Intercept</th>
+      <td class="gt_row gt_center">0.000 <br> (0.000)</td>
+      <td class="gt_row gt_center">0.000 <br> (0.000)</td>
+    </tr>
+    <tr class="gt_group_heading_row">
+      <th class="gt_group_heading" colspan="3">stats</th>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub">Observations</th>
+      <td class="gt_row gt_center">100</td>
+      <td class="gt_row gt_center">100</td>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub">R<sup>2</sup></th>
+      <td class="gt_row gt_center">1</td>
+      <td class="gt_row gt_center">1</td>
+    </tr>
+  </tbody>
+    <tfoot class="gt_sourcenotes">
+    
+    <tr>
+      <td class="gt_sourcenote" colspan="3">Significance levels: * p &lt; 0.1, ** p &lt; 0.05, *** p &lt; 0.01. Format of coefficient cell: Coefficient   (Std. Error)</td>
+    </tr>
+  
+  </tfoot>
+  
+  </table>
+  
+  </div>
+          
+  '''
+# ---
+# name: TestPyfixest.test_model[multi_model-latex]
+  '''
+  \begin{threeparttable}
+  \begingroup
+  \renewcommand\cellalign{t}
+  \renewcommand\arraystretch{1}
+  \setlength{\tabcolsep}{3pt}
+  \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}l>{\centering\arraybackslash}X>{\centering\arraybackslash}X}
+  \toprule
+   & \multicolumn{2}{c}{y} \\
+  \cmidrule(lr){2-3}
+   & (1) & (2) \\
+  \midrule
+  \addlinespace[1ex]
+  x & \makecell{2.100*** \\ (0.000)} & \makecell{2.100*** \\ (0.000)} \\
+  \addlinespace[0.5ex]
+  \addlinespace[0.5ex]
+  group=B &  & \makecell{-0.000 \\ (0.000)} \\
+  \addlinespace[0.5ex]
+  \addlinespace[0.5ex]
+  Intercept & \makecell{0.000 \\ (0.000)} & \makecell{0.000 \\ (0.000)} \\
+  \addlinespace[0.5ex]
+  \midrule
+  \addlinespace[1ex]
+  Observations & 100 & 100 \\
+  \addlinespace[0.5ex]
+  \addlinespace[0.5ex]
+  $R^2$ & 1 & 1 \\
+  \addlinespace[0.5ex]
+  \bottomrule
+  \end{tabularx}
+  \endgroup
+  \noindent\begin{minipage}{\linewidth}\smallskip\footnotesize
+  Significance levels: * p < 0.1, ** p < 0.05, *** p < 0.01. Format of coefficient cell: Coefficient   (Std. Error)\end{minipage}
+  
+  \end{threeparttable}
+  '''
+# ---
+# name: TestPyfixest.test_model[multi_model-typst]
+  '''
+  #table(
+    columns: (auto, 1fr, 1fr), align: (left, center, center),
+    column-gutter: (0em, 0em),
+    stroke: none, row-gutter: 0.2em,
+    table.hline(stroke: 0.08em),
+    [], [#table.cell(colspan: 2)[y]],
+    table.hline(stroke: 0.03em, start: 1, end: 3),
+    [], [(1)], [(2)],
+    table.hline(stroke: 0.05em),
+    table.hline(stroke: 0.03em),
+    [x], [2.100\*\*\* \ (0.000)], [2.100\*\*\* \ (0.000)],
+    [group=B], [], [-0.000 \ (0.000)],
+    [Intercept], [0.000 \ (0.000)], [0.000 \ (0.000)],
+    table.hline(stroke: 0.03em),
+    table.hline(stroke: 0.03em),
+    [Observations], [100], [100],
+    [$R^2$], [1], [1],
+    table.hline(stroke: 0.08em),
+    [#table.cell(colspan: 3)[#text(size: 10pt)[Significance levels: \* p \< 0.1, \*\* p \< 0.05, \*\*\* p \< 0.01. Format of coefficient cell: Coefficient   (Std. Error)]]],
+  )
+  '''
+# ---
+# name: TestPyfixest.test_model[single_model-html]
+  '''
+  <div id="STABLE_ID" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
+  <style>
+  #STABLE_ID table {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', 'Fira Sans', 'Droid Sans', Arial, sans-serif;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+          }
+  
+  #STABLE_ID thead, tbody, tfoot, tr, td, th { border-style: none; }
+   tr { background-color: transparent; }
+  #STABLE_ID p { margin: 0; padding: 0; }
+   #STABLE_ID .gt_table { display: table; border-collapse: collapse; line-height: normal; margin-left: auto; margin-right: auto; color: #333333; font-size: 16px; font-weight: normal; font-style: normal; background-color: #FFFFFF; width: auto; border-top-style: solid; border-top-width: 2px; border-top-color: #A8A8A8; border-right-style: none; border-right-width: 2px; border-right-color: #D3D3D3; border-bottom-style: hidden; border-bottom-width: 2px; border-bottom-color: #A8A8A8; border-left-style: none; border-left-width: 2px; border-left-color: #D3D3D3; }
+   #STABLE_ID .gt_caption { padding-top: 4px; padding-bottom: 4px; }
+   #STABLE_ID .gt_title { color: #333333; font-size: 16px; font-weight: initial; padding-top: 6px; padding-bottom: 6px; padding-left: 5px; padding-right: 5px; border-bottom-color: #FFFFFF; border-bottom-width: 0; }
+   #STABLE_ID .gt_subtitle { color: #333333; font-size: 85%; font-weight: initial; padding-top: 5px; padding-bottom: 7px; padding-left: 5px; padding-right: 5px; border-top-color: #FFFFFF; border-top-width: 0; }
+   #STABLE_ID .gt_heading { background-color: #FFFFFF; text-align: center; border-bottom-color: #FFFFFF; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; }
+   #STABLE_ID .gt_bottom_border { border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; }
+   #STABLE_ID .gt_col_headings { border-top-style: solid; border-top-width: 2px; border-top-color: black; border-bottom-style: solid; border-bottom-width: 0.25px; border-bottom-color: black; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; }
+   #STABLE_ID .gt_col_heading { color: #333333; background-color: #FFFFFF; font-size: 16px; font-weight: normal; text-transform: inherit; border-left-style: none; border-left-width: 0px; border-left-color: white; border-right-style: none; border-right-width: 0px; border-right-color: white; vertical-align: bottom; padding-top: 2px; padding-bottom: 7px; padding-left: 5px; padding-right: 5px; overflow-x: hidden; }
+   #STABLE_ID .gt_column_spanner_outer { color: #333333; background-color: #FFFFFF; font-size: 16px; font-weight: normal; text-transform: inherit; padding-top: 0; padding-bottom: 0; padding-left: 4px; padding-right: 4px; }
+   #STABLE_ID .gt_column_spanner_outer:first-child { padding-left: 0; }
+   #STABLE_ID .gt_column_spanner_outer:last-child { padding-right: 0; }
+   #STABLE_ID .gt_column_spanner { border-bottom-style: solid; border-bottom-width: 0.25px; border-bottom-color: black; vertical-align: bottom; padding-top: 2px; padding-bottom: 2px; overflow-x: hidden; display: inline-block; width: 100%; }
+   #STABLE_ID .gt_spanner_row { border-bottom-style: hidden; }
+   #STABLE_ID .gt_group_heading { padding-top: 0px; padding-bottom: 0px; padding-left: 5px; padding-right: 5px; color: #333333; background-color: #FFFFFF; font-size: 0px; font-weight: initial; text-transform: inherit; border-top-style: solid; border-top-width: 0.25px; border-top-color: black; border-bottom-style: solid; border-bottom-width: 0.25px; border-bottom-color: black; border-left-style: none; border-left-width: 1px; border-left-color: white; border-right-style: none; border-right-width: 1px; border-right-color: white; vertical-align: middle; text-align: left; }
+   #STABLE_ID .gt_empty_group_heading { padding: 0.5px; color: #333333; background-color: #FFFFFF; font-size: 0px; font-weight: initial; border-top-style: solid; border-top-width: 0.25px; border-top-color: black; border-bottom-style: solid; border-bottom-width: 0.25px; border-bottom-color: black; vertical-align: middle; }
+   #STABLE_ID .gt_from_md> :first-child { margin-top: 0; }
+   #STABLE_ID .gt_from_md> :last-child { margin-bottom: 0; }
+   #STABLE_ID .gt_row { padding-top: 2px; padding-bottom: 2px; padding-left: 5px; padding-right: 5px; margin: 10px; border-top-style: none; border-top-width: 1px; border-top-color: #D3D3D3; border-left-style: none; border-left-width: 0px; border-left-color: white; border-right-style: none; border-right-width: 0px; border-right-color: white; vertical-align: middle; overflow-x: hidden; }
+   #STABLE_ID .gt_stub { color: #333333; background-color: #FFFFFF; font-size: 16px; font-weight: initial; text-transform: inherit; border-right-style: hidden; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 5px; padding-right: 5px; }
+   #STABLE_ID .gt_stub_row_group { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 5px; padding-right: 5px; vertical-align: top; }
+   #STABLE_ID .gt_row_group_first td { border-top-width: 0.25px; }
+   #STABLE_ID .gt_row_group_first th { border-top-width: 0.25px; }
+   #STABLE_ID .gt_striped { background-color: rgba(128,128,128,0.05); }
+   #STABLE_ID .gt_table_body { border-top-style: solid; border-top-width: 0px; border-top-color: black; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: black; }
+   #STABLE_ID .gt_sourcenotes { color: #333333; background-color: #FFFFFF; border-bottom-style: none; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 2px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 2px; border-right-color: #D3D3D3; }
+   #STABLE_ID .gt_sourcenote { font-size: 10px; padding-top: 4px; padding-bottom: 4px; padding-left: 5px; padding-right: 5px; text-align: left; }
+   #STABLE_ID .gt_left { text-align: left; }
+   #STABLE_ID .gt_center { text-align: center; }
+   #STABLE_ID .gt_right { text-align: right; font-variant-numeric: tabular-nums; }
+   #STABLE_ID .gt_font_normal { font-weight: normal; }
+   #STABLE_ID .gt_font_bold { font-weight: bold; }
+   #STABLE_ID .gt_font_italic { font-style: italic; }
+   #STABLE_ID .gt_super { font-size: 65%; }
+   #STABLE_ID .gt_footnote_marks { font-size: 75%; vertical-align: 0.4em; position: initial; }
+   #STABLE_ID .gt_asterisk { font-size: 100%; vertical-align: 0; }
+   
+  </style>
+  <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
+  <thead>
+  
+  <tr class="gt_col_headings gt_spanner_row">
+    <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="2" colspan="1" scope="col" id=""></th>
+    <th class="gt_center gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="1" scope="col" id="y">
+      <span class="gt_column_spanner">y</span>
+    </th>
+  </tr>
+  <tr class="gt_col_headings">
+    <th class="gt_col_heading gt_columns_bottom_border gt_center" rowspan="1" colspan="1" scope="col" id="0">(1)</th>
+  </tr>
+  </thead>
+  <tbody class="gt_table_body">
+    <tr class="gt_group_heading_row">
+      <th class="gt_group_heading" colspan="2">coef</th>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub">x</th>
+      <td class="gt_row gt_center">2.000*** <br> (0.000)</td>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub">Intercept</th>
+      <td class="gt_row gt_center">0.100*** <br> (0.000)</td>
+    </tr>
+    <tr class="gt_group_heading_row">
+      <th class="gt_group_heading" colspan="2">stats</th>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub">Observations</th>
+      <td class="gt_row gt_center">100</td>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub">R<sup>2</sup></th>
+      <td class="gt_row gt_center">1</td>
+    </tr>
+  </tbody>
+    <tfoot class="gt_sourcenotes">
+    
+    <tr>
+      <td class="gt_sourcenote" colspan="2">Significance levels: * p &lt; 0.1, ** p &lt; 0.05, *** p &lt; 0.01. Format of coefficient cell: Coefficient   (Std. Error)</td>
+    </tr>
+  
+  </tfoot>
+  
+  </table>
+  
+  </div>
+          
+  '''
+# ---
+# name: TestPyfixest.test_model[single_model-latex]
+  '''
+  \begin{threeparttable}
+  \begingroup
+  \renewcommand\cellalign{t}
+  \renewcommand\arraystretch{1}
+  \setlength{\tabcolsep}{3pt}
+  \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}l>{\centering\arraybackslash}X}
+  \toprule
+   & \multicolumn{1}{c}{y} \\
+  \cmidrule(lr){2-2}
+   & (1) \\
+  \midrule
+  \addlinespace[1ex]
+  x & \makecell{2.000*** \\ (0.000)} \\
+  \addlinespace[0.5ex]
+  \addlinespace[0.5ex]
+  Intercept & \makecell{0.100*** \\ (0.000)} \\
+  \addlinespace[0.5ex]
+  \midrule
+  \addlinespace[1ex]
+  Observations & 100 \\
+  \addlinespace[0.5ex]
+  \addlinespace[0.5ex]
+  $R^2$ & 1 \\
+  \addlinespace[0.5ex]
+  \bottomrule
+  \end{tabularx}
+  \endgroup
+  \noindent\begin{minipage}{\linewidth}\smallskip\footnotesize
+  Significance levels: * p < 0.1, ** p < 0.05, *** p < 0.01. Format of coefficient cell: Coefficient   (Std. Error)\end{minipage}
+  
+  \end{threeparttable}
+  '''
+# ---
+# name: TestPyfixest.test_model[single_model-typst]
+  '''
+  #table(
+    columns: (auto, 1fr), align: (left, center),
+    column-gutter: (0em),
+    stroke: none, row-gutter: 0.2em,
+    table.hline(stroke: 0.08em),
+    [], [#table.cell(colspan: 1)[y]],
+    table.hline(stroke: 0.03em, start: 1, end: 2),
+    [], [(1)],
+    table.hline(stroke: 0.05em),
+    table.hline(stroke: 0.03em),
+    [x], [2.000\*\*\* \ (0.000)],
+    [Intercept], [0.100\*\*\* \ (0.000)],
+    table.hline(stroke: 0.03em),
+    table.hline(stroke: 0.03em),
+    [Observations], [100],
+    [$R^2$], [1],
+    table.hline(stroke: 0.08em),
+    [#table.cell(colspan: 2)[#text(size: 10pt)[Significance levels: \* p \< 0.1, \*\* p \< 0.05, \*\*\* p \< 0.01. Format of coefficient cell: Coefficient   (Std. Error)]]],
+  )
+  '''
+# ---
+# name: TestPyfixest.test_multi_fixest_with_stepwise[html]
   '''
   <div id="STABLE_ID" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
   <style>
@@ -320,7 +652,7 @@
           
   '''
 # ---
-# name: TestPyfixest.test_multi_fixest_with_stepwise_latex
+# name: TestPyfixest.test_multi_fixest_with_stepwise[latex]
   '''
   \begin{threeparttable}
   \begingroup
@@ -365,7 +697,7 @@
   \end{threeparttable}
   '''
 # ---
-# name: TestPyfixest.test_multi_fixest_with_stepwise_typst
+# name: TestPyfixest.test_multi_fixest_with_stepwise[typst]
   '''
   #table(
     columns: (auto, 1fr, 1fr, 1fr, 1fr, 1fr, 1fr), align: (left, center, center, center, center, center, center),
@@ -390,338 +722,6 @@
     [$R^2$], [0.133], [0.614], [0.162], [0.145], [0.574], [0.157],
     table.hline(stroke: 0.08em),
     [#table.cell(colspan: 7)[#text(size: 10pt)[Significance levels: \* p \< 0.1, \*\* p \< 0.05, \*\*\* p \< 0.01. Format of coefficient cell: Coefficient   (Std. Error)]]],
-  )
-  '''
-# ---
-# name: TestPyfixest.test_multi_model_html
-  '''
-  <div id="STABLE_ID" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
-  <style>
-  #STABLE_ID table {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', 'Fira Sans', 'Droid Sans', Arial, sans-serif;
-            -webkit-font-smoothing: antialiased;
-            -moz-osx-font-smoothing: grayscale;
-          }
-  
-  #STABLE_ID thead, tbody, tfoot, tr, td, th { border-style: none; }
-   tr { background-color: transparent; }
-  #STABLE_ID p { margin: 0; padding: 0; }
-   #STABLE_ID .gt_table { display: table; border-collapse: collapse; line-height: normal; margin-left: auto; margin-right: auto; color: #333333; font-size: 16px; font-weight: normal; font-style: normal; background-color: #FFFFFF; width: auto; border-top-style: solid; border-top-width: 2px; border-top-color: #A8A8A8; border-right-style: none; border-right-width: 2px; border-right-color: #D3D3D3; border-bottom-style: hidden; border-bottom-width: 2px; border-bottom-color: #A8A8A8; border-left-style: none; border-left-width: 2px; border-left-color: #D3D3D3; }
-   #STABLE_ID .gt_caption { padding-top: 4px; padding-bottom: 4px; }
-   #STABLE_ID .gt_title { color: #333333; font-size: 16px; font-weight: initial; padding-top: 6px; padding-bottom: 6px; padding-left: 5px; padding-right: 5px; border-bottom-color: #FFFFFF; border-bottom-width: 0; }
-   #STABLE_ID .gt_subtitle { color: #333333; font-size: 85%; font-weight: initial; padding-top: 5px; padding-bottom: 7px; padding-left: 5px; padding-right: 5px; border-top-color: #FFFFFF; border-top-width: 0; }
-   #STABLE_ID .gt_heading { background-color: #FFFFFF; text-align: center; border-bottom-color: #FFFFFF; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; }
-   #STABLE_ID .gt_bottom_border { border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; }
-   #STABLE_ID .gt_col_headings { border-top-style: solid; border-top-width: 2px; border-top-color: black; border-bottom-style: solid; border-bottom-width: 0.25px; border-bottom-color: black; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; }
-   #STABLE_ID .gt_col_heading { color: #333333; background-color: #FFFFFF; font-size: 16px; font-weight: normal; text-transform: inherit; border-left-style: none; border-left-width: 0px; border-left-color: white; border-right-style: none; border-right-width: 0px; border-right-color: white; vertical-align: bottom; padding-top: 2px; padding-bottom: 7px; padding-left: 5px; padding-right: 5px; overflow-x: hidden; }
-   #STABLE_ID .gt_column_spanner_outer { color: #333333; background-color: #FFFFFF; font-size: 16px; font-weight: normal; text-transform: inherit; padding-top: 0; padding-bottom: 0; padding-left: 4px; padding-right: 4px; }
-   #STABLE_ID .gt_column_spanner_outer:first-child { padding-left: 0; }
-   #STABLE_ID .gt_column_spanner_outer:last-child { padding-right: 0; }
-   #STABLE_ID .gt_column_spanner { border-bottom-style: solid; border-bottom-width: 0.25px; border-bottom-color: black; vertical-align: bottom; padding-top: 2px; padding-bottom: 2px; overflow-x: hidden; display: inline-block; width: 100%; }
-   #STABLE_ID .gt_spanner_row { border-bottom-style: hidden; }
-   #STABLE_ID .gt_group_heading { padding-top: 0px; padding-bottom: 0px; padding-left: 5px; padding-right: 5px; color: #333333; background-color: #FFFFFF; font-size: 0px; font-weight: initial; text-transform: inherit; border-top-style: solid; border-top-width: 0.25px; border-top-color: black; border-bottom-style: solid; border-bottom-width: 0.25px; border-bottom-color: black; border-left-style: none; border-left-width: 1px; border-left-color: white; border-right-style: none; border-right-width: 1px; border-right-color: white; vertical-align: middle; text-align: left; }
-   #STABLE_ID .gt_empty_group_heading { padding: 0.5px; color: #333333; background-color: #FFFFFF; font-size: 0px; font-weight: initial; border-top-style: solid; border-top-width: 0.25px; border-top-color: black; border-bottom-style: solid; border-bottom-width: 0.25px; border-bottom-color: black; vertical-align: middle; }
-   #STABLE_ID .gt_from_md> :first-child { margin-top: 0; }
-   #STABLE_ID .gt_from_md> :last-child { margin-bottom: 0; }
-   #STABLE_ID .gt_row { padding-top: 2px; padding-bottom: 2px; padding-left: 5px; padding-right: 5px; margin: 10px; border-top-style: none; border-top-width: 1px; border-top-color: #D3D3D3; border-left-style: none; border-left-width: 0px; border-left-color: white; border-right-style: none; border-right-width: 0px; border-right-color: white; vertical-align: middle; overflow-x: hidden; }
-   #STABLE_ID .gt_stub { color: #333333; background-color: #FFFFFF; font-size: 16px; font-weight: initial; text-transform: inherit; border-right-style: hidden; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 5px; padding-right: 5px; }
-   #STABLE_ID .gt_stub_row_group { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 5px; padding-right: 5px; vertical-align: top; }
-   #STABLE_ID .gt_row_group_first td { border-top-width: 0.25px; }
-   #STABLE_ID .gt_row_group_first th { border-top-width: 0.25px; }
-   #STABLE_ID .gt_striped { background-color: rgba(128,128,128,0.05); }
-   #STABLE_ID .gt_table_body { border-top-style: solid; border-top-width: 0px; border-top-color: black; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: black; }
-   #STABLE_ID .gt_sourcenotes { color: #333333; background-color: #FFFFFF; border-bottom-style: none; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 2px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 2px; border-right-color: #D3D3D3; }
-   #STABLE_ID .gt_sourcenote { font-size: 10px; padding-top: 4px; padding-bottom: 4px; padding-left: 5px; padding-right: 5px; text-align: left; }
-   #STABLE_ID .gt_left { text-align: left; }
-   #STABLE_ID .gt_center { text-align: center; }
-   #STABLE_ID .gt_right { text-align: right; font-variant-numeric: tabular-nums; }
-   #STABLE_ID .gt_font_normal { font-weight: normal; }
-   #STABLE_ID .gt_font_bold { font-weight: bold; }
-   #STABLE_ID .gt_font_italic { font-style: italic; }
-   #STABLE_ID .gt_super { font-size: 65%; }
-   #STABLE_ID .gt_footnote_marks { font-size: 75%; vertical-align: 0.4em; position: initial; }
-   #STABLE_ID .gt_asterisk { font-size: 100%; vertical-align: 0; }
-   
-  </style>
-  <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
-  <thead>
-  
-  <tr class="gt_col_headings gt_spanner_row">
-    <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="2" colspan="1" scope="col" id=""></th>
-    <th class="gt_center gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="2" scope="colgroup" id="y">
-      <span class="gt_column_spanner">y</span>
-    </th>
-  </tr>
-  <tr class="gt_col_headings">
-    <th class="gt_col_heading gt_columns_bottom_border gt_center" rowspan="1" colspan="1" scope="col" id="0">(1)</th>
-    <th class="gt_col_heading gt_columns_bottom_border gt_center" rowspan="1" colspan="1" scope="col" id="1">(2)</th>
-  </tr>
-  </thead>
-  <tbody class="gt_table_body">
-    <tr class="gt_group_heading_row">
-      <th class="gt_group_heading" colspan="3">coef</th>
-    </tr>
-    <tr>
-      <th class="gt_row gt_left gt_stub">x</th>
-      <td class="gt_row gt_center">2.100*** <br> (0.000)</td>
-      <td class="gt_row gt_center">2.100*** <br> (0.000)</td>
-    </tr>
-    <tr>
-      <th class="gt_row gt_left gt_stub">group=B</th>
-      <td class="gt_row gt_center"></td>
-      <td class="gt_row gt_center">-0.000 <br> (0.000)</td>
-    </tr>
-    <tr>
-      <th class="gt_row gt_left gt_stub">Intercept</th>
-      <td class="gt_row gt_center">0.000 <br> (0.000)</td>
-      <td class="gt_row gt_center">0.000 <br> (0.000)</td>
-    </tr>
-    <tr class="gt_group_heading_row">
-      <th class="gt_group_heading" colspan="3">stats</th>
-    </tr>
-    <tr>
-      <th class="gt_row gt_left gt_stub">Observations</th>
-      <td class="gt_row gt_center">100</td>
-      <td class="gt_row gt_center">100</td>
-    </tr>
-    <tr>
-      <th class="gt_row gt_left gt_stub">R<sup>2</sup></th>
-      <td class="gt_row gt_center">1</td>
-      <td class="gt_row gt_center">1</td>
-    </tr>
-  </tbody>
-    <tfoot class="gt_sourcenotes">
-    
-    <tr>
-      <td class="gt_sourcenote" colspan="3">Significance levels: * p &lt; 0.1, ** p &lt; 0.05, *** p &lt; 0.01. Format of coefficient cell: Coefficient   (Std. Error)</td>
-    </tr>
-  
-  </tfoot>
-  
-  </table>
-  
-  </div>
-          
-  '''
-# ---
-# name: TestPyfixest.test_multi_model_latex
-  '''
-  \begin{threeparttable}
-  \begingroup
-  \renewcommand\cellalign{t}
-  \renewcommand\arraystretch{1}
-  \setlength{\tabcolsep}{3pt}
-  \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}l>{\centering\arraybackslash}X>{\centering\arraybackslash}X}
-  \toprule
-   & \multicolumn{2}{c}{y} \\
-  \cmidrule(lr){2-3}
-   & (1) & (2) \\
-  \midrule
-  \addlinespace[1ex]
-  x & \makecell{2.100*** \\ (0.000)} & \makecell{2.100*** \\ (0.000)} \\
-  \addlinespace[0.5ex]
-  \addlinespace[0.5ex]
-  group=B &  & \makecell{-0.000 \\ (0.000)} \\
-  \addlinespace[0.5ex]
-  \addlinespace[0.5ex]
-  Intercept & \makecell{0.000 \\ (0.000)} & \makecell{0.000 \\ (0.000)} \\
-  \addlinespace[0.5ex]
-  \midrule
-  \addlinespace[1ex]
-  Observations & 100 & 100 \\
-  \addlinespace[0.5ex]
-  \addlinespace[0.5ex]
-  $R^2$ & 1 & 1 \\
-  \addlinespace[0.5ex]
-  \bottomrule
-  \end{tabularx}
-  \endgroup
-  \noindent\begin{minipage}{\linewidth}\smallskip\footnotesize
-  Significance levels: * p < 0.1, ** p < 0.05, *** p < 0.01. Format of coefficient cell: Coefficient   (Std. Error)\end{minipage}
-  
-  \end{threeparttable}
-  '''
-# ---
-# name: TestPyfixest.test_multi_model_typst
-  '''
-  #table(
-    columns: (auto, 1fr, 1fr), align: (left, center, center),
-    column-gutter: (0em, 0em),
-    stroke: none, row-gutter: 0.2em,
-    table.hline(stroke: 0.08em),
-    [], [#table.cell(colspan: 2)[y]],
-    table.hline(stroke: 0.03em, start: 1, end: 3),
-    [], [(1)], [(2)],
-    table.hline(stroke: 0.05em),
-    table.hline(stroke: 0.03em),
-    [x], [2.100\*\*\* \ (0.000)], [2.100\*\*\* \ (0.000)],
-    [group=B], [], [-0.000 \ (0.000)],
-    [Intercept], [0.000 \ (0.000)], [0.000 \ (0.000)],
-    table.hline(stroke: 0.03em),
-    table.hline(stroke: 0.03em),
-    [Observations], [100], [100],
-    [$R^2$], [1], [1],
-    table.hline(stroke: 0.08em),
-    [#table.cell(colspan: 3)[#text(size: 10pt)[Significance levels: \* p \< 0.1, \*\* p \< 0.05, \*\*\* p \< 0.01. Format of coefficient cell: Coefficient   (Std. Error)]]],
-  )
-  '''
-# ---
-# name: TestPyfixest.test_single_model_html
-  '''
-  <div id="STABLE_ID" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
-  <style>
-  #STABLE_ID table {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', 'Fira Sans', 'Droid Sans', Arial, sans-serif;
-            -webkit-font-smoothing: antialiased;
-            -moz-osx-font-smoothing: grayscale;
-          }
-  
-  #STABLE_ID thead, tbody, tfoot, tr, td, th { border-style: none; }
-   tr { background-color: transparent; }
-  #STABLE_ID p { margin: 0; padding: 0; }
-   #STABLE_ID .gt_table { display: table; border-collapse: collapse; line-height: normal; margin-left: auto; margin-right: auto; color: #333333; font-size: 16px; font-weight: normal; font-style: normal; background-color: #FFFFFF; width: auto; border-top-style: solid; border-top-width: 2px; border-top-color: #A8A8A8; border-right-style: none; border-right-width: 2px; border-right-color: #D3D3D3; border-bottom-style: hidden; border-bottom-width: 2px; border-bottom-color: #A8A8A8; border-left-style: none; border-left-width: 2px; border-left-color: #D3D3D3; }
-   #STABLE_ID .gt_caption { padding-top: 4px; padding-bottom: 4px; }
-   #STABLE_ID .gt_title { color: #333333; font-size: 16px; font-weight: initial; padding-top: 6px; padding-bottom: 6px; padding-left: 5px; padding-right: 5px; border-bottom-color: #FFFFFF; border-bottom-width: 0; }
-   #STABLE_ID .gt_subtitle { color: #333333; font-size: 85%; font-weight: initial; padding-top: 5px; padding-bottom: 7px; padding-left: 5px; padding-right: 5px; border-top-color: #FFFFFF; border-top-width: 0; }
-   #STABLE_ID .gt_heading { background-color: #FFFFFF; text-align: center; border-bottom-color: #FFFFFF; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; }
-   #STABLE_ID .gt_bottom_border { border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; }
-   #STABLE_ID .gt_col_headings { border-top-style: solid; border-top-width: 2px; border-top-color: black; border-bottom-style: solid; border-bottom-width: 0.25px; border-bottom-color: black; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; }
-   #STABLE_ID .gt_col_heading { color: #333333; background-color: #FFFFFF; font-size: 16px; font-weight: normal; text-transform: inherit; border-left-style: none; border-left-width: 0px; border-left-color: white; border-right-style: none; border-right-width: 0px; border-right-color: white; vertical-align: bottom; padding-top: 2px; padding-bottom: 7px; padding-left: 5px; padding-right: 5px; overflow-x: hidden; }
-   #STABLE_ID .gt_column_spanner_outer { color: #333333; background-color: #FFFFFF; font-size: 16px; font-weight: normal; text-transform: inherit; padding-top: 0; padding-bottom: 0; padding-left: 4px; padding-right: 4px; }
-   #STABLE_ID .gt_column_spanner_outer:first-child { padding-left: 0; }
-   #STABLE_ID .gt_column_spanner_outer:last-child { padding-right: 0; }
-   #STABLE_ID .gt_column_spanner { border-bottom-style: solid; border-bottom-width: 0.25px; border-bottom-color: black; vertical-align: bottom; padding-top: 2px; padding-bottom: 2px; overflow-x: hidden; display: inline-block; width: 100%; }
-   #STABLE_ID .gt_spanner_row { border-bottom-style: hidden; }
-   #STABLE_ID .gt_group_heading { padding-top: 0px; padding-bottom: 0px; padding-left: 5px; padding-right: 5px; color: #333333; background-color: #FFFFFF; font-size: 0px; font-weight: initial; text-transform: inherit; border-top-style: solid; border-top-width: 0.25px; border-top-color: black; border-bottom-style: solid; border-bottom-width: 0.25px; border-bottom-color: black; border-left-style: none; border-left-width: 1px; border-left-color: white; border-right-style: none; border-right-width: 1px; border-right-color: white; vertical-align: middle; text-align: left; }
-   #STABLE_ID .gt_empty_group_heading { padding: 0.5px; color: #333333; background-color: #FFFFFF; font-size: 0px; font-weight: initial; border-top-style: solid; border-top-width: 0.25px; border-top-color: black; border-bottom-style: solid; border-bottom-width: 0.25px; border-bottom-color: black; vertical-align: middle; }
-   #STABLE_ID .gt_from_md> :first-child { margin-top: 0; }
-   #STABLE_ID .gt_from_md> :last-child { margin-bottom: 0; }
-   #STABLE_ID .gt_row { padding-top: 2px; padding-bottom: 2px; padding-left: 5px; padding-right: 5px; margin: 10px; border-top-style: none; border-top-width: 1px; border-top-color: #D3D3D3; border-left-style: none; border-left-width: 0px; border-left-color: white; border-right-style: none; border-right-width: 0px; border-right-color: white; vertical-align: middle; overflow-x: hidden; }
-   #STABLE_ID .gt_stub { color: #333333; background-color: #FFFFFF; font-size: 16px; font-weight: initial; text-transform: inherit; border-right-style: hidden; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 5px; padding-right: 5px; }
-   #STABLE_ID .gt_stub_row_group { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 5px; padding-right: 5px; vertical-align: top; }
-   #STABLE_ID .gt_row_group_first td { border-top-width: 0.25px; }
-   #STABLE_ID .gt_row_group_first th { border-top-width: 0.25px; }
-   #STABLE_ID .gt_striped { background-color: rgba(128,128,128,0.05); }
-   #STABLE_ID .gt_table_body { border-top-style: solid; border-top-width: 0px; border-top-color: black; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: black; }
-   #STABLE_ID .gt_sourcenotes { color: #333333; background-color: #FFFFFF; border-bottom-style: none; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 2px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 2px; border-right-color: #D3D3D3; }
-   #STABLE_ID .gt_sourcenote { font-size: 10px; padding-top: 4px; padding-bottom: 4px; padding-left: 5px; padding-right: 5px; text-align: left; }
-   #STABLE_ID .gt_left { text-align: left; }
-   #STABLE_ID .gt_center { text-align: center; }
-   #STABLE_ID .gt_right { text-align: right; font-variant-numeric: tabular-nums; }
-   #STABLE_ID .gt_font_normal { font-weight: normal; }
-   #STABLE_ID .gt_font_bold { font-weight: bold; }
-   #STABLE_ID .gt_font_italic { font-style: italic; }
-   #STABLE_ID .gt_super { font-size: 65%; }
-   #STABLE_ID .gt_footnote_marks { font-size: 75%; vertical-align: 0.4em; position: initial; }
-   #STABLE_ID .gt_asterisk { font-size: 100%; vertical-align: 0; }
-   
-  </style>
-  <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
-  <thead>
-  
-  <tr class="gt_col_headings gt_spanner_row">
-    <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="2" colspan="1" scope="col" id=""></th>
-    <th class="gt_center gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="1" scope="col" id="y">
-      <span class="gt_column_spanner">y</span>
-    </th>
-  </tr>
-  <tr class="gt_col_headings">
-    <th class="gt_col_heading gt_columns_bottom_border gt_center" rowspan="1" colspan="1" scope="col" id="0">(1)</th>
-  </tr>
-  </thead>
-  <tbody class="gt_table_body">
-    <tr class="gt_group_heading_row">
-      <th class="gt_group_heading" colspan="2">coef</th>
-    </tr>
-    <tr>
-      <th class="gt_row gt_left gt_stub">x</th>
-      <td class="gt_row gt_center">2.000*** <br> (0.000)</td>
-    </tr>
-    <tr>
-      <th class="gt_row gt_left gt_stub">Intercept</th>
-      <td class="gt_row gt_center">0.100*** <br> (0.000)</td>
-    </tr>
-    <tr class="gt_group_heading_row">
-      <th class="gt_group_heading" colspan="2">stats</th>
-    </tr>
-    <tr>
-      <th class="gt_row gt_left gt_stub">Observations</th>
-      <td class="gt_row gt_center">100</td>
-    </tr>
-    <tr>
-      <th class="gt_row gt_left gt_stub">R<sup>2</sup></th>
-      <td class="gt_row gt_center">1</td>
-    </tr>
-  </tbody>
-    <tfoot class="gt_sourcenotes">
-    
-    <tr>
-      <td class="gt_sourcenote" colspan="2">Significance levels: * p &lt; 0.1, ** p &lt; 0.05, *** p &lt; 0.01. Format of coefficient cell: Coefficient   (Std. Error)</td>
-    </tr>
-  
-  </tfoot>
-  
-  </table>
-  
-  </div>
-          
-  '''
-# ---
-# name: TestPyfixest.test_single_model_latex
-  '''
-  \begin{threeparttable}
-  \begingroup
-  \renewcommand\cellalign{t}
-  \renewcommand\arraystretch{1}
-  \setlength{\tabcolsep}{3pt}
-  \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}l>{\centering\arraybackslash}X}
-  \toprule
-   & \multicolumn{1}{c}{y} \\
-  \cmidrule(lr){2-2}
-   & (1) \\
-  \midrule
-  \addlinespace[1ex]
-  x & \makecell{2.000*** \\ (0.000)} \\
-  \addlinespace[0.5ex]
-  \addlinespace[0.5ex]
-  Intercept & \makecell{0.100*** \\ (0.000)} \\
-  \addlinespace[0.5ex]
-  \midrule
-  \addlinespace[1ex]
-  Observations & 100 \\
-  \addlinespace[0.5ex]
-  \addlinespace[0.5ex]
-  $R^2$ & 1 \\
-  \addlinespace[0.5ex]
-  \bottomrule
-  \end{tabularx}
-  \endgroup
-  \noindent\begin{minipage}{\linewidth}\smallskip\footnotesize
-  Significance levels: * p < 0.1, ** p < 0.05, *** p < 0.01. Format of coefficient cell: Coefficient   (Std. Error)\end{minipage}
-  
-  \end{threeparttable}
-  '''
-# ---
-# name: TestPyfixest.test_single_model_typst
-  '''
-  #table(
-    columns: (auto, 1fr), align: (left, center),
-    column-gutter: (0em),
-    stroke: none, row-gutter: 0.2em,
-    table.hline(stroke: 0.08em),
-    [], [#table.cell(colspan: 1)[y]],
-    table.hline(stroke: 0.03em, start: 1, end: 2),
-    [], [(1)],
-    table.hline(stroke: 0.05em),
-    table.hline(stroke: 0.03em),
-    [x], [2.000\*\*\* \ (0.000)],
-    [Intercept], [0.100\*\*\* \ (0.000)],
-    table.hline(stroke: 0.03em),
-    table.hline(stroke: 0.03em),
-    [Observations], [100],
-    [$R^2$], [1],
-    table.hline(stroke: 0.08em),
-    [#table.cell(colspan: 2)[#text(size: 10pt)[Significance levels: \* p \< 0.1, \*\* p \< 0.05, \*\*\* p \< 0.01. Format of coefficient cell: Coefficient   (Std. Error)]]],
   )
   '''
 # ---

--- a/tests/models/__snapshots__/test_pyfixest.ambr
+++ b/tests/models/__snapshots__/test_pyfixest.ambr
@@ -416,12 +416,12 @@
     <tr>
       <th class="gt_row gt_left gt_stub">group=B</th>
       <td class="gt_row gt_center"></td>
-      <td class="gt_row gt_center">-0.000*** <br> (0.000)</td>
+      <td class="gt_row gt_center">-0.000 <br> (0.000)</td>
     </tr>
     <tr>
       <th class="gt_row gt_left gt_stub">Intercept</th>
-      <td class="gt_row gt_center">0.000** <br> (0.000)</td>
-      <td class="gt_row gt_center">0.000*** <br> (0.000)</td>
+      <td class="gt_row gt_center">0.000 <br> (0.000)</td>
+      <td class="gt_row gt_center">0.000 <br> (0.000)</td>
     </tr>
     <tr class="gt_group_heading_row">
       <th class="gt_group_heading" colspan="3">stats</th>
@@ -468,10 +468,10 @@
   x & \makecell{2.100*** \\ (0.000)} & \makecell{2.100*** \\ (0.000)} \\
   \addlinespace[0.5ex]
   \addlinespace[0.5ex]
-  group=B &  & \makecell{-0.000*** \\ (0.000)} \\
+  group=B &  & \makecell{-0.000 \\ (0.000)} \\
   \addlinespace[0.5ex]
   \addlinespace[0.5ex]
-  Intercept & \makecell{0.000** \\ (0.000)} & \makecell{0.000*** \\ (0.000)} \\
+  Intercept & \makecell{0.000 \\ (0.000)} & \makecell{0.000 \\ (0.000)} \\
   \addlinespace[0.5ex]
   \midrule
   \addlinespace[1ex]

--- a/tests/models/__snapshots__/test_pyfixest.ambr
+++ b/tests/models/__snapshots__/test_pyfixest.ambr
@@ -139,6 +139,31 @@
   \end{threeparttable}
   '''
 # ---
+# name: TestPyfixest.test_fixed_effects_typst
+  '''
+  #table(
+    columns: (auto, 1fr), align: (left, center),
+    column-gutter: (0em),
+    stroke: none, row-gutter: 0.2em,
+    table.hline(stroke: 0.08em),
+    [], [#table.cell(colspan: 1)[y]],
+    table.hline(stroke: 0.03em, start: 1, end: 2),
+    [], [(1)],
+    table.hline(stroke: 0.05em),
+    table.hline(stroke: 0.03em),
+    [x], [2.100\*\*\* \ (0.000)],
+    table.hline(stroke: 0.03em),
+    table.hline(stroke: 0.03em),
+    [group], [x],
+    table.hline(stroke: 0.03em),
+    table.hline(stroke: 0.03em),
+    [Observations], [100],
+    [$R^2$], [1],
+    table.hline(stroke: 0.08em),
+    [#table.cell(colspan: 2)[#text(size: 10pt)[Significance levels: \* p \< 0.1, \*\* p \< 0.05, \*\*\* p \< 0.01. Format of coefficient cell: Coefficient   (Std. Error)]]],
+  )
+  '''
+# ---
 # name: TestPyfixest.test_multi_fixest_with_stepwise_html
   '''
   <div id="STABLE_ID" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
@@ -340,6 +365,34 @@
   \end{threeparttable}
   '''
 # ---
+# name: TestPyfixest.test_multi_fixest_with_stepwise_typst
+  '''
+  #table(
+    columns: (auto, 1fr, 1fr, 1fr, 1fr, 1fr, 1fr), align: (left, center, center, center, center, center, center),
+    column-gutter: (0em, 0em, 0em, 0em, 0em, 0em),
+    stroke: none, row-gutter: 0.2em,
+    table.hline(stroke: 0.08em),
+    [], [#table.cell(colspan: 6)[Y]],
+    table.hline(stroke: 0.03em, start: 1, end: 7),
+    [], [(1)], [(2)], [(3)], [(4)], [(5)], [(6)],
+    table.hline(stroke: 0.05em),
+    table.hline(stroke: 0.03em),
+    [X1], [0.862\*\*\* \ (0.225)], [0.736\*\* \ (0.206)], [0.947\*\*\* \ (0.217)], [], [], [],
+    [X2], [], [], [], [-0.209\*\*\* \ (0.052)], [-0.147\*\*\* \ (0.039)], [-0.210\*\*\* \ (0.043)],
+    [Intercept], [0.929\*\*\* \ (0.272)], [], [], [1.560\*\*\* \ (0.180)], [], [],
+    table.hline(stroke: 0.03em),
+    table.hline(stroke: 0.03em),
+    [f1], [-], [x], [-], [-], [x], [-],
+    [f2], [-], [-], [x], [-], [-], [x],
+    table.hline(stroke: 0.03em),
+    table.hline(stroke: 0.03em),
+    [Observations], [98], [97], [98], [99], [98], [99],
+    [$R^2$], [0.133], [0.614], [0.162], [0.145], [0.574], [0.157],
+    table.hline(stroke: 0.08em),
+    [#table.cell(colspan: 7)[#text(size: 10pt)[Significance levels: \* p \< 0.1, \*\* p \< 0.05, \*\*\* p \< 0.01. Format of coefficient cell: Coefficient   (Std. Error)]]],
+  )
+  '''
+# ---
 # name: TestPyfixest.test_multi_model_html
   '''
   <div id="STABLE_ID" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
@@ -489,6 +542,30 @@
   \end{threeparttable}
   '''
 # ---
+# name: TestPyfixest.test_multi_model_typst
+  '''
+  #table(
+    columns: (auto, 1fr, 1fr), align: (left, center, center),
+    column-gutter: (0em, 0em),
+    stroke: none, row-gutter: 0.2em,
+    table.hline(stroke: 0.08em),
+    [], [#table.cell(colspan: 2)[y]],
+    table.hline(stroke: 0.03em, start: 1, end: 3),
+    [], [(1)], [(2)],
+    table.hline(stroke: 0.05em),
+    table.hline(stroke: 0.03em),
+    [x], [2.100\*\*\* \ (0.000)], [2.100\*\*\* \ (0.000)],
+    [group=B], [], [-0.000 \ (0.000)],
+    [Intercept], [0.000 \ (0.000)], [0.000 \ (0.000)],
+    table.hline(stroke: 0.03em),
+    table.hline(stroke: 0.03em),
+    [Observations], [100], [100],
+    [$R^2$], [1], [1],
+    table.hline(stroke: 0.08em),
+    [#table.cell(colspan: 3)[#text(size: 10pt)[Significance levels: \* p \< 0.1, \*\* p \< 0.05, \*\*\* p \< 0.01. Format of coefficient cell: Coefficient   (Std. Error)]]],
+  )
+  '''
+# ---
 # name: TestPyfixest.test_single_model_html
   '''
   <div id="STABLE_ID" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
@@ -623,5 +700,28 @@
   Significance levels: * p < 0.1, ** p < 0.05, *** p < 0.01. Format of coefficient cell: Coefficient   (Std. Error)\end{minipage}
   
   \end{threeparttable}
+  '''
+# ---
+# name: TestPyfixest.test_single_model_typst
+  '''
+  #table(
+    columns: (auto, 1fr), align: (left, center),
+    column-gutter: (0em),
+    stroke: none, row-gutter: 0.2em,
+    table.hline(stroke: 0.08em),
+    [], [#table.cell(colspan: 1)[y]],
+    table.hline(stroke: 0.03em, start: 1, end: 2),
+    [], [(1)],
+    table.hline(stroke: 0.05em),
+    table.hline(stroke: 0.03em),
+    [x], [2.000\*\*\* \ (0.000)],
+    [Intercept], [0.100\*\*\* \ (0.000)],
+    table.hline(stroke: 0.03em),
+    table.hline(stroke: 0.03em),
+    [Observations], [100],
+    [$R^2$], [1],
+    table.hline(stroke: 0.08em),
+    [#table.cell(colspan: 2)[#text(size: 10pt)[Significance levels: \* p \< 0.1, \*\* p \< 0.05, \*\*\* p \< 0.01. Format of coefficient cell: Coefficient   (Std. Error)]]],
+  )
   '''
 # ---

--- a/tests/models/__snapshots__/test_pyfixest.ambr
+++ b/tests/models/__snapshots__/test_pyfixest.ambr
@@ -8,7 +8,7 @@
             -webkit-font-smoothing: antialiased;
             -moz-osx-font-smoothing: grayscale;
           }
-  
+
   #STABLE_ID thead, tbody, tfoot, tr, td, th { border-style: none; }
    tr { background-color: transparent; }
   #STABLE_ID p { margin: 0; padding: 0; }
@@ -47,11 +47,11 @@
    #STABLE_ID .gt_super { font-size: 65%; }
    #STABLE_ID .gt_footnote_marks { font-size: 75%; vertical-align: 0.4em; position: initial; }
    #STABLE_ID .gt_asterisk { font-size: 100%; vertical-align: 0; }
-   
+
   </style>
   <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>
-  
+
   <tr class="gt_col_headings gt_spanner_row">
     <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="2" colspan="1" scope="col" id=""></th>
     <th class="gt_center gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="1" scope="col" id="y">
@@ -90,17 +90,17 @@
     </tr>
   </tbody>
     <tfoot class="gt_sourcenotes">
-    
+
     <tr>
       <td class="gt_sourcenote" colspan="2">Significance levels: * p &lt; 0.1, ** p &lt; 0.05, *** p &lt; 0.01. Format of coefficient cell: Coefficient   (Std. Error)</td>
     </tr>
-  
+
   </tfoot>
-  
+
   </table>
-  
+
   </div>
-          
+
   '''
 # ---
 # name: TestPyfixest.test_model[fixed_effects-latex]
@@ -135,7 +135,7 @@
   \endgroup
   \noindent\begin{minipage}{\linewidth}\smallskip\footnotesize
   Significance levels: * p < 0.1, ** p < 0.05, *** p < 0.01. Format of coefficient cell: Coefficient   (Std. Error)\end{minipage}
-  
+
   \end{threeparttable}
   '''
 # ---
@@ -173,7 +173,7 @@
             -webkit-font-smoothing: antialiased;
             -moz-osx-font-smoothing: grayscale;
           }
-  
+
   #STABLE_ID thead, tbody, tfoot, tr, td, th { border-style: none; }
    tr { background-color: transparent; }
   #STABLE_ID p { margin: 0; padding: 0; }
@@ -212,11 +212,11 @@
    #STABLE_ID .gt_super { font-size: 65%; }
    #STABLE_ID .gt_footnote_marks { font-size: 75%; vertical-align: 0.4em; position: initial; }
    #STABLE_ID .gt_asterisk { font-size: 100%; vertical-align: 0; }
-   
+
   </style>
   <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>
-  
+
   <tr class="gt_col_headings gt_spanner_row">
     <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="2" colspan="1" scope="col" id=""></th>
     <th class="gt_center gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="2" scope="colgroup" id="y">
@@ -262,17 +262,17 @@
     </tr>
   </tbody>
     <tfoot class="gt_sourcenotes">
-    
+
     <tr>
       <td class="gt_sourcenote" colspan="3">Significance levels: * p &lt; 0.1, ** p &lt; 0.05, *** p &lt; 0.01. Format of coefficient cell: Coefficient   (Std. Error)</td>
     </tr>
-  
+
   </tfoot>
-  
+
   </table>
-  
+
   </div>
-          
+
   '''
 # ---
 # name: TestPyfixest.test_model[multi_model-latex]
@@ -309,7 +309,7 @@
   \endgroup
   \noindent\begin{minipage}{\linewidth}\smallskip\footnotesize
   Significance levels: * p < 0.1, ** p < 0.05, *** p < 0.01. Format of coefficient cell: Coefficient   (Std. Error)\end{minipage}
-  
+
   \end{threeparttable}
   '''
 # ---
@@ -346,7 +346,7 @@
             -webkit-font-smoothing: antialiased;
             -moz-osx-font-smoothing: grayscale;
           }
-  
+
   #STABLE_ID thead, tbody, tfoot, tr, td, th { border-style: none; }
    tr { background-color: transparent; }
   #STABLE_ID p { margin: 0; padding: 0; }
@@ -385,11 +385,11 @@
    #STABLE_ID .gt_super { font-size: 65%; }
    #STABLE_ID .gt_footnote_marks { font-size: 75%; vertical-align: 0.4em; position: initial; }
    #STABLE_ID .gt_asterisk { font-size: 100%; vertical-align: 0; }
-   
+
   </style>
   <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>
-  
+
   <tr class="gt_col_headings gt_spanner_row">
     <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="2" colspan="1" scope="col" id=""></th>
     <th class="gt_center gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="1" scope="col" id="y">
@@ -425,17 +425,17 @@
     </tr>
   </tbody>
     <tfoot class="gt_sourcenotes">
-    
+
     <tr>
       <td class="gt_sourcenote" colspan="2">Significance levels: * p &lt; 0.1, ** p &lt; 0.05, *** p &lt; 0.01. Format of coefficient cell: Coefficient   (Std. Error)</td>
     </tr>
-  
+
   </tfoot>
-  
+
   </table>
-  
+
   </div>
-          
+
   '''
 # ---
 # name: TestPyfixest.test_model[single_model-latex]
@@ -469,7 +469,7 @@
   \endgroup
   \noindent\begin{minipage}{\linewidth}\smallskip\footnotesize
   Significance levels: * p < 0.1, ** p < 0.05, *** p < 0.01. Format of coefficient cell: Coefficient   (Std. Error)\end{minipage}
-  
+
   \end{threeparttable}
   '''
 # ---
@@ -505,7 +505,7 @@
             -webkit-font-smoothing: antialiased;
             -moz-osx-font-smoothing: grayscale;
           }
-  
+
   #STABLE_ID thead, tbody, tfoot, tr, td, th { border-style: none; }
    tr { background-color: transparent; }
   #STABLE_ID p { margin: 0; padding: 0; }
@@ -544,11 +544,11 @@
    #STABLE_ID .gt_super { font-size: 65%; }
    #STABLE_ID .gt_footnote_marks { font-size: 75%; vertical-align: 0.4em; position: initial; }
    #STABLE_ID .gt_asterisk { font-size: 100%; vertical-align: 0; }
-   
+
   </style>
   <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>
-  
+
   <tr class="gt_col_headings gt_spanner_row">
     <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="2" colspan="1" scope="col" id=""></th>
     <th class="gt_center gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="6" scope="colgroup" id="Y">
@@ -639,17 +639,17 @@
     </tr>
   </tbody>
     <tfoot class="gt_sourcenotes">
-    
+
     <tr>
       <td class="gt_sourcenote" colspan="7">Significance levels: * p &lt; 0.1, ** p &lt; 0.05, *** p &lt; 0.01. Format of coefficient cell: Coefficient   (Std. Error)</td>
     </tr>
-  
+
   </tfoot>
-  
+
   </table>
-  
+
   </div>
-          
+
   '''
 # ---
 # name: TestPyfixest.test_multi_fixest_with_stepwise[latex]
@@ -693,7 +693,7 @@
   \endgroup
   \noindent\begin{minipage}{\linewidth}\smallskip\footnotesize
   Significance levels: * p < 0.1, ** p < 0.05, *** p < 0.01. Format of coefficient cell: Coefficient   (Std. Error)\end{minipage}
-  
+
   \end{threeparttable}
   '''
 # ---

--- a/tests/models/__snapshots__/test_statsmodels.ambr
+++ b/tests/models/__snapshots__/test_statsmodels.ambr
@@ -8,7 +8,7 @@
             -webkit-font-smoothing: antialiased;
             -moz-osx-font-smoothing: grayscale;
           }
-  
+
   #STABLE_ID thead, tbody, tfoot, tr, td, th { border-style: none; }
    tr { background-color: transparent; }
   #STABLE_ID p { margin: 0; padding: 0; }
@@ -47,11 +47,11 @@
    #STABLE_ID .gt_super { font-size: 65%; }
    #STABLE_ID .gt_footnote_marks { font-size: 75%; vertical-align: 0.4em; position: initial; }
    #STABLE_ID .gt_asterisk { font-size: 100%; vertical-align: 0; }
-   
+
   </style>
   <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>
-  
+
   <tr class="gt_col_headings gt_spanner_row">
     <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="2" colspan="1" scope="col" id=""></th>
     <th class="gt_center gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="1" scope="col" id="y_binary">
@@ -91,17 +91,17 @@
     </tr>
   </tbody>
     <tfoot class="gt_sourcenotes">
-    
+
     <tr>
       <td class="gt_sourcenote" colspan="2">Significance levels: * p &lt; 0.1, ** p &lt; 0.05, *** p &lt; 0.01. Format of coefficient cell: Coefficient   (Std. Error)</td>
     </tr>
-  
+
   </tfoot>
-  
+
   </table>
-  
+
   </div>
-          
+
   '''
 # ---
 # name: TestStatsmodels.test_model[logit-latex]
@@ -138,7 +138,7 @@
   \endgroup
   \noindent\begin{minipage}{\linewidth}\smallskip\footnotesize
   Significance levels: * p < 0.1, ** p < 0.05, *** p < 0.01. Format of coefficient cell: Coefficient   (Std. Error)\end{minipage}
-  
+
   \end{threeparttable}
   '''
 # ---
@@ -175,7 +175,7 @@
             -webkit-font-smoothing: antialiased;
             -moz-osx-font-smoothing: grayscale;
           }
-  
+
   #STABLE_ID thead, tbody, tfoot, tr, td, th { border-style: none; }
    tr { background-color: transparent; }
   #STABLE_ID p { margin: 0; padding: 0; }
@@ -214,11 +214,11 @@
    #STABLE_ID .gt_super { font-size: 65%; }
    #STABLE_ID .gt_footnote_marks { font-size: 75%; vertical-align: 0.4em; position: initial; }
    #STABLE_ID .gt_asterisk { font-size: 100%; vertical-align: 0; }
-   
+
   </style>
   <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>
-  
+
   <tr class="gt_col_headings gt_spanner_row">
     <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="2" colspan="1" scope="col" id=""></th>
     <th class="gt_center gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="1" scope="col" id="y">
@@ -254,17 +254,17 @@
     </tr>
   </tbody>
     <tfoot class="gt_sourcenotes">
-    
+
     <tr>
       <td class="gt_sourcenote" colspan="2">Significance levels: * p &lt; 0.1, ** p &lt; 0.05, *** p &lt; 0.01. Format of coefficient cell: Coefficient   (Std. Error)</td>
     </tr>
-  
+
   </tfoot>
-  
+
   </table>
-  
+
   </div>
-          
+
   '''
 # ---
 # name: TestStatsmodels.test_model[ols-latex]
@@ -298,7 +298,7 @@
   \endgroup
   \noindent\begin{minipage}{\linewidth}\smallskip\footnotesize
   Significance levels: * p < 0.1, ** p < 0.05, *** p < 0.01. Format of coefficient cell: Coefficient   (Std. Error)\end{minipage}
-  
+
   \end{threeparttable}
   '''
 # ---
@@ -334,7 +334,7 @@
             -webkit-font-smoothing: antialiased;
             -moz-osx-font-smoothing: grayscale;
           }
-  
+
   #STABLE_ID thead, tbody, tfoot, tr, td, th { border-style: none; }
    tr { background-color: transparent; }
   #STABLE_ID p { margin: 0; padding: 0; }
@@ -373,11 +373,11 @@
    #STABLE_ID .gt_super { font-size: 65%; }
    #STABLE_ID .gt_footnote_marks { font-size: 75%; vertical-align: 0.4em; position: initial; }
    #STABLE_ID .gt_asterisk { font-size: 100%; vertical-align: 0; }
-   
+
   </style>
   <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>
-  
+
   <tr class="gt_col_headings gt_spanner_row">
     <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="2" colspan="1" scope="col" id=""></th>
     <th class="gt_center gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="1" scope="col" id="y_binary">
@@ -417,17 +417,17 @@
     </tr>
   </tbody>
     <tfoot class="gt_sourcenotes">
-    
+
     <tr>
       <td class="gt_sourcenote" colspan="2">Significance levels: * p &lt; 0.1, ** p &lt; 0.05, *** p &lt; 0.01. Format of coefficient cell: Coefficient   (Std. Error)</td>
     </tr>
-  
+
   </tfoot>
-  
+
   </table>
-  
+
   </div>
-          
+
   '''
 # ---
 # name: TestStatsmodels.test_model[probit-latex]
@@ -464,7 +464,7 @@
   \endgroup
   \noindent\begin{minipage}{\linewidth}\smallskip\footnotesize
   Significance levels: * p < 0.1, ** p < 0.05, *** p < 0.01. Format of coefficient cell: Coefficient   (Std. Error)\end{minipage}
-  
+
   \end{threeparttable}
   '''
 # ---

--- a/tests/models/__snapshots__/test_statsmodels.ambr
+++ b/tests/models/__snapshots__/test_statsmodels.ambr
@@ -142,6 +142,30 @@
   \end{threeparttable}
   '''
 # ---
+# name: TestStatsmodels.test_logit_typst
+  '''
+  #table(
+    columns: (auto, 1fr), align: (left, center),
+    column-gutter: (0em),
+    stroke: none, row-gutter: 0.2em,
+    table.hline(stroke: 0.08em),
+    [], [#table.cell(colspan: 1)[y\_binary]],
+    table.hline(stroke: 0.03em, start: 1, end: 2),
+    [], [(1)],
+    table.hline(stroke: 0.05em),
+    table.hline(stroke: 0.03em),
+    [x], [1933.784 \ (614063.360)],
+    [Intercept], [8.106 \ (6267.036)],
+    table.hline(stroke: 0.03em),
+    table.hline(stroke: 0.03em),
+    [Observations], [100],
+    [Pseudo $R^2$], [1],
+    [Log-likelihood], [-0],
+    table.hline(stroke: 0.08em),
+    [#table.cell(colspan: 2)[#text(size: 10pt)[Significance levels: \* p \< 0.1, \*\* p \< 0.05, \*\*\* p \< 0.01. Format of coefficient cell: Coefficient   (Std. Error)]]],
+  )
+  '''
+# ---
 # name: TestStatsmodels.test_ols_html
   '''
   <div id="STABLE_ID" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
@@ -276,6 +300,29 @@
   Significance levels: * p < 0.1, ** p < 0.05, *** p < 0.01. Format of coefficient cell: Coefficient   (Std. Error)\end{minipage}
   
   \end{threeparttable}
+  '''
+# ---
+# name: TestStatsmodels.test_ols_typst
+  '''
+  #table(
+    columns: (auto, 1fr), align: (left, center),
+    column-gutter: (0em),
+    stroke: none, row-gutter: 0.2em,
+    table.hline(stroke: 0.08em),
+    [], [#table.cell(colspan: 1)[y]],
+    table.hline(stroke: 0.03em, start: 1, end: 2),
+    [], [(1)],
+    table.hline(stroke: 0.05em),
+    table.hline(stroke: 0.03em),
+    [x], [2.100\*\*\* \ (0.000)],
+    [Intercept], [0.000\*\*\* \ (0.000)],
+    table.hline(stroke: 0.03em),
+    table.hline(stroke: 0.03em),
+    [Observations], [100],
+    [$R^2$], [1],
+    table.hline(stroke: 0.08em),
+    [#table.cell(colspan: 2)[#text(size: 10pt)[Significance levels: \* p \< 0.1, \*\* p \< 0.05, \*\*\* p \< 0.01. Format of coefficient cell: Coefficient   (Std. Error)]]],
+  )
   '''
 # ---
 # name: TestStatsmodels.test_probit_html
@@ -419,5 +466,29 @@
   Significance levels: * p < 0.1, ** p < 0.05, *** p < 0.01. Format of coefficient cell: Coefficient   (Std. Error)\end{minipage}
   
   \end{threeparttable}
+  '''
+# ---
+# name: TestStatsmodels.test_probit_typst
+  '''
+  #table(
+    columns: (auto, 1fr), align: (left, center),
+    column-gutter: (0em),
+    stroke: none, row-gutter: 0.2em,
+    table.hline(stroke: 0.08em),
+    [], [#table.cell(colspan: 1)[y\_binary]],
+    table.hline(stroke: 0.03em, start: 1, end: 2),
+    [], [(1)],
+    table.hline(stroke: 0.05em),
+    table.hline(stroke: 0.03em),
+    [x], [940.384 \ (140417681969.216)],
+    [Intercept], [4.646 \ (1895244764.470)],
+    table.hline(stroke: 0.03em),
+    table.hline(stroke: 0.03em),
+    [Observations], [100],
+    [Pseudo $R^2$], [1],
+    [Log-likelihood], [0],
+    table.hline(stroke: 0.08em),
+    [#table.cell(colspan: 2)[#text(size: 10pt)[Significance levels: \* p \< 0.1, \*\* p \< 0.05, \*\*\* p \< 0.01. Format of coefficient cell: Coefficient   (Std. Error)]]],
+  )
   '''
 # ---

--- a/tests/models/__snapshots__/test_statsmodels.ambr
+++ b/tests/models/__snapshots__/test_statsmodels.ambr
@@ -347,11 +347,11 @@
     </tr>
     <tr>
       <th class="gt_row gt_left gt_stub">x</th>
-      <td class="gt_row gt_center">940.384 <br> (140417681969.961)</td>
+      <td class="gt_row gt_center">940.384 <br> (140417681969.216)</td>
     </tr>
     <tr>
       <th class="gt_row gt_left gt_stub">Intercept</th>
-      <td class="gt_row gt_center">4.646 <br> (1895244764.480)</td>
+      <td class="gt_row gt_center">4.646 <br> (1895244764.470)</td>
     </tr>
     <tr class="gt_group_heading_row">
       <th class="gt_group_heading" colspan="2">stats</th>
@@ -397,10 +397,10 @@
    & (1) \\
   \midrule
   \addlinespace[1ex]
-  x & \makecell{940.384 \\ (140417681969.961)} \\
+  x & \makecell{940.384 \\ (140417681969.216)} \\
   \addlinespace[0.5ex]
   \addlinespace[0.5ex]
-  Intercept & \makecell{4.646 \\ (1895244764.480)} \\
+  Intercept & \makecell{4.646 \\ (1895244764.470)} \\
   \addlinespace[0.5ex]
   \midrule
   \addlinespace[1ex]

--- a/tests/models/__snapshots__/test_statsmodels.ambr
+++ b/tests/models/__snapshots__/test_statsmodels.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: TestStatsmodels.test_logit_html
+# name: TestStatsmodels.test_model[logit-html]
   '''
   <div id="STABLE_ID" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
   <style>
@@ -104,7 +104,7 @@
           
   '''
 # ---
-# name: TestStatsmodels.test_logit_latex
+# name: TestStatsmodels.test_model[logit-latex]
   '''
   \begin{threeparttable}
   \begingroup
@@ -142,7 +142,7 @@
   \end{threeparttable}
   '''
 # ---
-# name: TestStatsmodels.test_logit_typst
+# name: TestStatsmodels.test_model[logit-typst]
   '''
   #table(
     columns: (auto, 1fr), align: (left, center),
@@ -166,7 +166,7 @@
   )
   '''
 # ---
-# name: TestStatsmodels.test_ols_html
+# name: TestStatsmodels.test_model[ols-html]
   '''
   <div id="STABLE_ID" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
   <style>
@@ -267,7 +267,7 @@
           
   '''
 # ---
-# name: TestStatsmodels.test_ols_latex
+# name: TestStatsmodels.test_model[ols-latex]
   '''
   \begin{threeparttable}
   \begingroup
@@ -302,7 +302,7 @@
   \end{threeparttable}
   '''
 # ---
-# name: TestStatsmodels.test_ols_typst
+# name: TestStatsmodels.test_model[ols-typst]
   '''
   #table(
     columns: (auto, 1fr), align: (left, center),
@@ -325,7 +325,7 @@
   )
   '''
 # ---
-# name: TestStatsmodels.test_probit_html
+# name: TestStatsmodels.test_model[probit-html]
   '''
   <div id="STABLE_ID" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
   <style>
@@ -430,7 +430,7 @@
           
   '''
 # ---
-# name: TestStatsmodels.test_probit_latex
+# name: TestStatsmodels.test_model[probit-latex]
   '''
   \begin{threeparttable}
   \begingroup
@@ -468,7 +468,7 @@
   \end{threeparttable}
   '''
 # ---
-# name: TestStatsmodels.test_probit_typst
+# name: TestStatsmodels.test_model[probit-typst]
   '''
   #table(
     columns: (auto, 1fr), align: (left, center),

--- a/tests/models/test_linearmodels.py
+++ b/tests/models/test_linearmodels.py
@@ -17,6 +17,11 @@ class TestLinearmodels:
         table = mt.ETable([linearmodels_panelols])
         assert table.make(type="tex") == snapshot
 
+    def test_panelols_typst(self, linearmodels_panelols, snapshot):
+        """Linearmodels PanelOLS Typst output."""
+        table = mt.ETable([linearmodels_panelols])
+        assert table.make(type="typst") == snapshot
+
     def test_pooledols_html(self, linearmodels_pooledols, snapshot):
         """Linearmodels PooledOLS HTML output."""
         table = mt.ETable([linearmodels_pooledols])
@@ -26,6 +31,11 @@ class TestLinearmodels:
         """Linearmodels PooledOLS LaTeX output."""
         table = mt.ETable([linearmodels_pooledols])
         assert table.make(type="tex") == snapshot
+
+    def test_pooledols_typst(self, linearmodels_pooledols, snapshot):
+        """Linearmodels PooledOLS Typst output."""
+        table = mt.ETable([linearmodels_pooledols])
+        assert table.make(type="typst") == snapshot
 
     def test_absorbingls_html(self, linearmodels_absorbingls, snapshot):
         """Linearmodels AbsorbingLS HTML output."""
@@ -37,6 +47,11 @@ class TestLinearmodels:
         table = mt.ETable([linearmodels_absorbingls])
         assert table.make(type="tex") == snapshot
 
+    def test_absorbingls_typst(self, linearmodels_absorbingls, snapshot):
+        """Linearmodels AbsorbingLS Typst output."""
+        table = mt.ETable([linearmodels_absorbingls])
+        assert table.make(type="typst") == snapshot
+
     def test_iv2sls_html(self, linearmodels_iv2sls, snapshot):
         """Linearmodels IV2SLS HTML output."""
         table = mt.ETable([linearmodels_iv2sls])
@@ -46,3 +61,8 @@ class TestLinearmodels:
         """Linearmodels IV2SLS LaTeX output."""
         table = mt.ETable([linearmodels_iv2sls])
         assert table.make(type="tex") == snapshot
+
+    def test_iv2sls_typst(self, linearmodels_iv2sls, snapshot):
+        """Linearmodels IV2SLS Typst output."""
+        table = mt.ETable([linearmodels_iv2sls])
+        assert table.make(type="typst") == snapshot

--- a/tests/models/test_linearmodels.py
+++ b/tests/models/test_linearmodels.py
@@ -1,8 +1,9 @@
 """Base snapshot tests for linearmodels models."""
 
-import maketables as mt
 import pytest
 from helpers import OUTPUT_TYPES, render_table
+
+import maketables as mt
 
 
 class TestLinearmodels:

--- a/tests/models/test_linearmodels.py
+++ b/tests/models/test_linearmodels.py
@@ -1,68 +1,25 @@
 """Base snapshot tests for linearmodels models."""
 
 import maketables as mt
-from helpers import normalize_html
+import pytest
+from helpers import OUTPUT_TYPES, render_table
 
 
 class TestLinearmodels:
     """Base tests for linearmodels model extraction."""
 
-    def test_panelols_html(self, linearmodels_panelols, snapshot):
-        """Linearmodels PanelOLS HTML output."""
-        table = mt.ETable([linearmodels_panelols])
-        assert normalize_html(table.make(type="gt").as_raw_html()) == snapshot
-
-    def test_panelols_latex(self, linearmodels_panelols, snapshot):
-        """Linearmodels PanelOLS LaTeX output."""
-        table = mt.ETable([linearmodels_panelols])
-        assert table.make(type="tex") == snapshot
-
-    def test_panelols_typst(self, linearmodels_panelols, snapshot):
-        """Linearmodels PanelOLS Typst output."""
-        table = mt.ETable([linearmodels_panelols])
-        assert table.make(type="typst") == snapshot
-
-    def test_pooledols_html(self, linearmodels_pooledols, snapshot):
-        """Linearmodels PooledOLS HTML output."""
-        table = mt.ETable([linearmodels_pooledols])
-        assert normalize_html(table.make(type="gt").as_raw_html()) == snapshot
-
-    def test_pooledols_latex(self, linearmodels_pooledols, snapshot):
-        """Linearmodels PooledOLS LaTeX output."""
-        table = mt.ETable([linearmodels_pooledols])
-        assert table.make(type="tex") == snapshot
-
-    def test_pooledols_typst(self, linearmodels_pooledols, snapshot):
-        """Linearmodels PooledOLS Typst output."""
-        table = mt.ETable([linearmodels_pooledols])
-        assert table.make(type="typst") == snapshot
-
-    def test_absorbingls_html(self, linearmodels_absorbingls, snapshot):
-        """Linearmodels AbsorbingLS HTML output."""
-        table = mt.ETable([linearmodels_absorbingls])
-        assert normalize_html(table.make(type="gt").as_raw_html()) == snapshot
-
-    def test_absorbingls_latex(self, linearmodels_absorbingls, snapshot):
-        """Linearmodels AbsorbingLS LaTeX output."""
-        table = mt.ETable([linearmodels_absorbingls])
-        assert table.make(type="tex") == snapshot
-
-    def test_absorbingls_typst(self, linearmodels_absorbingls, snapshot):
-        """Linearmodels AbsorbingLS Typst output."""
-        table = mt.ETable([linearmodels_absorbingls])
-        assert table.make(type="typst") == snapshot
-
-    def test_iv2sls_html(self, linearmodels_iv2sls, snapshot):
-        """Linearmodels IV2SLS HTML output."""
-        table = mt.ETable([linearmodels_iv2sls])
-        assert normalize_html(table.make(type="gt").as_raw_html()) == snapshot
-
-    def test_iv2sls_latex(self, linearmodels_iv2sls, snapshot):
-        """Linearmodels IV2SLS LaTeX output."""
-        table = mt.ETable([linearmodels_iv2sls])
-        assert table.make(type="tex") == snapshot
-
-    def test_iv2sls_typst(self, linearmodels_iv2sls, snapshot):
-        """Linearmodels IV2SLS Typst output."""
-        table = mt.ETable([linearmodels_iv2sls])
-        assert table.make(type="typst") == snapshot
+    @pytest.mark.parametrize("output_type", OUTPUT_TYPES)
+    @pytest.mark.parametrize(
+        "model_fixture",
+        [
+            pytest.param("linearmodels_panelols", id="panelols"),
+            pytest.param("linearmodels_pooledols", id="pooledols"),
+            pytest.param("linearmodels_absorbingls", id="absorbingls"),
+            pytest.param("linearmodels_iv2sls", id="iv2sls"),
+        ],
+    )
+    def test_model(self, request, snapshot, model_fixture, output_type):
+        """Linearmodels model output."""
+        model = request.getfixturevalue(model_fixture)
+        table = mt.ETable([model])
+        assert render_table(table, output_type) == snapshot

--- a/tests/models/test_pyfixest.py
+++ b/tests/models/test_pyfixest.py
@@ -17,6 +17,11 @@ class TestPyfixest:
         table = mt.ETable([fitted_model])
         assert table.make(type="tex") == snapshot
 
+    def test_single_model_typst(self, fitted_model, snapshot):
+        """Single pyfixest model Typst output."""
+        table = mt.ETable([fitted_model])
+        assert table.make(type="typst") == snapshot
+
     def test_multi_model_html(self, fitted_models, snapshot):
         """Multiple pyfixest models HTML output."""
         table = mt.ETable(fitted_models)
@@ -26,6 +31,11 @@ class TestPyfixest:
         """Multiple pyfixest models LaTeX output."""
         table = mt.ETable(fitted_models)
         assert table.make(type="tex") == snapshot
+
+    def test_multi_model_typst(self, fitted_models, snapshot):
+        """Multiple pyfixest models Typst output."""
+        table = mt.ETable(fitted_models)
+        assert table.make(type="typst") == snapshot
 
     def test_fixed_effects_html(self, fitted_model_fe, snapshot):
         """Pyfixest model with fixed effects HTML output."""
@@ -37,18 +47,23 @@ class TestPyfixest:
         table = mt.ETable([fitted_model_fe])
         assert table.make(type="tex") == snapshot
 
+    def test_fixed_effects_typst(self, fitted_model_fe, snapshot):
+        """Pyfixest model with fixed effects Typst output."""
+        table = mt.ETable([fitted_model_fe])
+        assert table.make(type="typst") == snapshot
+
     def test_multi_fixest_with_stepwise_html(self, snapshot):
         """Multiple pyfixest formulas with stepwise notation (FixestMulti objects)."""
         import pyfixest as pf
         import numpy as np
-        
+
         np.random.seed(42)
         df = pf.get_data(N=100, seed=0, model="Feols")
-        
+
         # Create list of FixestMulti objects (stepwise notation in each formula)
         fmls = ['Y ~ X1 | sw0(f1, f2)', 'Y ~ X2 | sw0(f1, f2)']
         models = [pf.feols(fml=fml, data=df) for fml in fmls]
-        
+
         # Should expand FixestMulti objects and create a table
         table = mt.ETable(models)
         assert normalize_html(table.make(type="gt").as_raw_html()) == snapshot
@@ -57,14 +72,30 @@ class TestPyfixest:
         """Multiple pyfixest formulas with stepwise notation (FixestMulti objects)."""
         import pyfixest as pf
         import numpy as np
-        
+
         np.random.seed(42)
         df = pf.get_data(N=100, seed=0, model="Feols")
-        
+
         # Create list of FixestMulti objects (stepwise notation in each formula)
         fmls = ['Y ~ X1 | sw0(f1, f2)', 'Y ~ X2 | sw0(f1, f2)']
         models = [pf.feols(fml=fml, data=df) for fml in fmls]
-        
+
         # Should expand FixestMulti objects and create a table
         table = mt.ETable(models)
         assert table.make(type="tex") == snapshot
+
+    def test_multi_fixest_with_stepwise_typst(self, snapshot):
+        """Multiple pyfixest formulas with stepwise notation (FixestMulti objects)."""
+        import pyfixest as pf
+        import numpy as np
+
+        np.random.seed(42)
+        df = pf.get_data(N=100, seed=0, model="Feols")
+
+        # Create list of FixestMulti objects (stepwise notation in each formula)
+        fmls = ["Y ~ X1 | sw0(f1, f2)", "Y ~ X2 | sw0(f1, f2)"]
+        models = [pf.feols(fml=fml, data=df) for fml in fmls]
+
+        # Should expand FixestMulti objects and create a table
+        table = mt.ETable(models)
+        assert table.make(type="typst") == snapshot

--- a/tests/models/test_pyfixest.py
+++ b/tests/models/test_pyfixest.py
@@ -1,59 +1,34 @@
 """Base snapshot tests for pyfixest models."""
 
 import maketables as mt
-from helpers import normalize_html
+import pytest
+from helpers import OUTPUT_TYPES, render_table
 
 
 class TestPyfixest:
     """Base tests for pyfixest model extraction."""
 
-    def test_single_model_html(self, fitted_model, snapshot):
-        """Single pyfixest model HTML output."""
-        table = mt.ETable([fitted_model])
-        assert normalize_html(table.make(type="gt").as_raw_html()) == snapshot
+    @pytest.mark.parametrize("output_type", OUTPUT_TYPES)
+    @pytest.mark.parametrize(
+        "model_fixture",
+        [
+            pytest.param("fitted_model", id="single_model"),
+            pytest.param("fitted_models", id="multi_model"),
+            pytest.param("fitted_model_fe", id="fixed_effects"),
+        ],
+    )
+    def test_model(self, request, snapshot, model_fixture, output_type):
+        """Pyfixest model output."""
+        models = request.getfixturevalue(model_fixture)
+        if not isinstance(models, list):
+            models = [models]
 
-    def test_single_model_latex(self, fitted_model, snapshot):
-        """Single pyfixest model LaTeX output."""
-        table = mt.ETable([fitted_model])
-        assert table.make(type="tex") == snapshot
+        table = mt.ETable(models)
+        assert render_table(table, output_type) == snapshot
 
-    def test_single_model_typst(self, fitted_model, snapshot):
-        """Single pyfixest model Typst output."""
-        table = mt.ETable([fitted_model])
-        assert table.make(type="typst") == snapshot
-
-    def test_multi_model_html(self, fitted_models, snapshot):
-        """Multiple pyfixest models HTML output."""
-        table = mt.ETable(fitted_models)
-        assert normalize_html(table.make(type="gt").as_raw_html()) == snapshot
-
-    def test_multi_model_latex(self, fitted_models, snapshot):
-        """Multiple pyfixest models LaTeX output."""
-        table = mt.ETable(fitted_models)
-        assert table.make(type="tex") == snapshot
-
-    def test_multi_model_typst(self, fitted_models, snapshot):
-        """Multiple pyfixest models Typst output."""
-        table = mt.ETable(fitted_models)
-        assert table.make(type="typst") == snapshot
-
-    def test_fixed_effects_html(self, fitted_model_fe, snapshot):
-        """Pyfixest model with fixed effects HTML output."""
-        table = mt.ETable([fitted_model_fe])
-        assert normalize_html(table.make(type="gt").as_raw_html()) == snapshot
-
-    def test_fixed_effects_latex(self, fitted_model_fe, snapshot):
-        """Pyfixest model with fixed effects LaTeX output."""
-        table = mt.ETable([fitted_model_fe])
-        assert table.make(type="tex") == snapshot
-
-    def test_fixed_effects_typst(self, fitted_model_fe, snapshot):
-        """Pyfixest model with fixed effects Typst output."""
-        table = mt.ETable([fitted_model_fe])
-        assert table.make(type="typst") == snapshot
-
-    def test_multi_fixest_with_stepwise_html(self, snapshot):
-        """Multiple pyfixest formulas with stepwise notation (FixestMulti objects)."""
+    @pytest.mark.parametrize("output_type", OUTPUT_TYPES)
+    def test_multi_fixest_with_stepwise(self, snapshot, output_type):
+        """Multiple pyfixest formulas with stepwise notation."""
         import pyfixest as pf
         import numpy as np
 
@@ -66,36 +41,4 @@ class TestPyfixest:
 
         # Should expand FixestMulti objects and create a table
         table = mt.ETable(models)
-        assert normalize_html(table.make(type="gt").as_raw_html()) == snapshot
-
-    def test_multi_fixest_with_stepwise_latex(self, snapshot):
-        """Multiple pyfixest formulas with stepwise notation (FixestMulti objects)."""
-        import pyfixest as pf
-        import numpy as np
-
-        np.random.seed(42)
-        df = pf.get_data(N=100, seed=0, model="Feols")
-
-        # Create list of FixestMulti objects (stepwise notation in each formula)
-        fmls = ['Y ~ X1 | sw0(f1, f2)', 'Y ~ X2 | sw0(f1, f2)']
-        models = [pf.feols(fml=fml, data=df) for fml in fmls]
-
-        # Should expand FixestMulti objects and create a table
-        table = mt.ETable(models)
-        assert table.make(type="tex") == snapshot
-
-    def test_multi_fixest_with_stepwise_typst(self, snapshot):
-        """Multiple pyfixest formulas with stepwise notation (FixestMulti objects)."""
-        import pyfixest as pf
-        import numpy as np
-
-        np.random.seed(42)
-        df = pf.get_data(N=100, seed=0, model="Feols")
-
-        # Create list of FixestMulti objects (stepwise notation in each formula)
-        fmls = ["Y ~ X1 | sw0(f1, f2)", "Y ~ X2 | sw0(f1, f2)"]
-        models = [pf.feols(fml=fml, data=df) for fml in fmls]
-
-        # Should expand FixestMulti objects and create a table
-        table = mt.ETable(models)
-        assert table.make(type="typst") == snapshot
+        assert render_table(table, output_type) == snapshot

--- a/tests/models/test_pyfixest.py
+++ b/tests/models/test_pyfixest.py
@@ -1,8 +1,9 @@
 """Base snapshot tests for pyfixest models."""
 
-import maketables as mt
 import pytest
 from helpers import OUTPUT_TYPES, render_table
+
+import maketables as mt
 
 
 class TestPyfixest:
@@ -29,14 +30,14 @@ class TestPyfixest:
     @pytest.mark.parametrize("output_type", OUTPUT_TYPES)
     def test_multi_fixest_with_stepwise(self, snapshot, output_type):
         """Multiple pyfixest formulas with stepwise notation."""
-        import pyfixest as pf
         import numpy as np
+        import pyfixest as pf
 
         np.random.seed(42)
         df = pf.get_data(N=100, seed=0, model="Feols")
 
         # Create list of FixestMulti objects (stepwise notation in each formula)
-        fmls = ['Y ~ X1 | sw0(f1, f2)', 'Y ~ X2 | sw0(f1, f2)']
+        fmls = ["Y ~ X1 | sw0(f1, f2)", "Y ~ X2 | sw0(f1, f2)"]
         models = [pf.feols(fml=fml, data=df) for fml in fmls]
 
         # Should expand FixestMulti objects and create a table

--- a/tests/models/test_statsmodels.py
+++ b/tests/models/test_statsmodels.py
@@ -1,53 +1,24 @@
 """Base snapshot tests for statsmodels models."""
 
 import maketables as mt
-from helpers import normalize_html
+import pytest
+from helpers import OUTPUT_TYPES, render_table
 
 
 class TestStatsmodels:
     """Base tests for statsmodels model extraction."""
 
-    def test_ols_html(self, statsmodels_ols, snapshot):
-        """Statsmodels OLS HTML output."""
-        table = mt.ETable([statsmodels_ols])
-        assert normalize_html(table.make(type="gt").as_raw_html()) == snapshot
-
-    def test_ols_latex(self, statsmodels_ols, snapshot):
-        """Statsmodels OLS LaTeX output."""
-        table = mt.ETable([statsmodels_ols])
-        assert table.make(type="tex") == snapshot
-
-    def test_ols_typst(self, statsmodels_ols, snapshot):
-        """Statsmodels OLS Typst output."""
-        table = mt.ETable([statsmodels_ols])
-        assert table.make(type="typst") == snapshot
-
-    def test_logit_html(self, statsmodels_logit, snapshot):
-        """Statsmodels Logit HTML output."""
-        table = mt.ETable([statsmodels_logit])
-        assert normalize_html(table.make(type="gt").as_raw_html()) == snapshot
-
-    def test_logit_latex(self, statsmodels_logit, snapshot):
-        """Statsmodels Logit LaTeX output."""
-        table = mt.ETable([statsmodels_logit])
-        assert table.make(type="tex") == snapshot
-
-    def test_logit_typst(self, statsmodels_logit, snapshot):
-        """Statsmodels Logit Typst output."""
-        table = mt.ETable([statsmodels_logit])
-        assert table.make(type="typst") == snapshot
-
-    def test_probit_html(self, statsmodels_probit, snapshot):
-        """Statsmodels Probit HTML output."""
-        table = mt.ETable([statsmodels_probit])
-        assert normalize_html(table.make(type="gt").as_raw_html()) == snapshot
-
-    def test_probit_latex(self, statsmodels_probit, snapshot):
-        """Statsmodels Probit LaTeX output."""
-        table = mt.ETable([statsmodels_probit])
-        assert table.make(type="tex") == snapshot
-
-    def test_probit_typst(self, statsmodels_probit, snapshot):
-        """Statsmodels Probit Typst output."""
-        table = mt.ETable([statsmodels_probit])
-        assert table.make(type="typst") == snapshot
+    @pytest.mark.parametrize("output_type", OUTPUT_TYPES)
+    @pytest.mark.parametrize(
+        "model_fixture",
+        [
+            pytest.param("statsmodels_ols", id="ols"),
+            pytest.param("statsmodels_logit", id="logit"),
+            pytest.param("statsmodels_probit", id="probit"),
+        ],
+    )
+    def test_model(self, request, snapshot, model_fixture, output_type):
+        """Statsmodels model output."""
+        model = request.getfixturevalue(model_fixture)
+        table = mt.ETable([model])
+        assert render_table(table, output_type) == snapshot

--- a/tests/models/test_statsmodels.py
+++ b/tests/models/test_statsmodels.py
@@ -17,6 +17,11 @@ class TestStatsmodels:
         table = mt.ETable([statsmodels_ols])
         assert table.make(type="tex") == snapshot
 
+    def test_ols_typst(self, statsmodels_ols, snapshot):
+        """Statsmodels OLS Typst output."""
+        table = mt.ETable([statsmodels_ols])
+        assert table.make(type="typst") == snapshot
+
     def test_logit_html(self, statsmodels_logit, snapshot):
         """Statsmodels Logit HTML output."""
         table = mt.ETable([statsmodels_logit])
@@ -27,6 +32,11 @@ class TestStatsmodels:
         table = mt.ETable([statsmodels_logit])
         assert table.make(type="tex") == snapshot
 
+    def test_logit_typst(self, statsmodels_logit, snapshot):
+        """Statsmodels Logit Typst output."""
+        table = mt.ETable([statsmodels_logit])
+        assert table.make(type="typst") == snapshot
+
     def test_probit_html(self, statsmodels_probit, snapshot):
         """Statsmodels Probit HTML output."""
         table = mt.ETable([statsmodels_probit])
@@ -36,3 +46,8 @@ class TestStatsmodels:
         """Statsmodels Probit LaTeX output."""
         table = mt.ETable([statsmodels_probit])
         assert table.make(type="tex") == snapshot
+
+    def test_probit_typst(self, statsmodels_probit, snapshot):
+        """Statsmodels Probit Typst output."""
+        table = mt.ETable([statsmodels_probit])
+        assert table.make(type="typst") == snapshot

--- a/tests/models/test_statsmodels.py
+++ b/tests/models/test_statsmodels.py
@@ -1,8 +1,9 @@
 """Base snapshot tests for statsmodels models."""
 
-import maketables as mt
 import pytest
 from helpers import OUTPUT_TYPES, render_table
+
+import maketables as mt
 
 
 class TestStatsmodels:


### PR DESCRIPTION
See second part in #47.

- Allows BTable(group=...) to accept either a single column name or a list of column names.
- Passes list-valued groups through to DTable(bycol=...) so grouped column combinations are displayed.
- Uses a temporary combined group factor for BTable p-value regressions when multiple grouping columns are provided.
- Adds fixture-based snapshot coverage for a 2x2 grouped BTable case and updates BTable reference docs.