### PR TITLE
feat: add `stats_order`

### DIFF
--- a/docs/ETable.ipynb
+++ b/docs/ETable.ipynb
@@ -5549,7 +5549,7 @@
    "metadata": {},
    "source": [
     "## Further custom model information\n",
-    "You can add further custom model statistics/information to the bottom of the table by using the `custom_stats` argument to which you pass a dictionary with the name of the row and lists of values. The length of the lists must be equal to the number of models.\n"
+    "You can add further custom model statistics/information to the bottom of the table by using the `custom_model_stats` argument to which you pass a dictionary with the name of the row and lists of values. The length of the lists must be equal to the number of models. By default, custom statistics are displayed before the model statistics (`stats_order=\"cs\"`). Use `stats_order=\"sc\"` to display model statistics first. As with `head_order`, a single letter displays only that block and an empty string hides both blocks.\n"
    ]
   },
   {

--- a/src/maketables/etable.py
+++ b/src/maketables/etable.py
@@ -4,13 +4,16 @@ import re
 import warnings
 from collections import Counter
 from collections.abc import ValuesView
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Literal
 
 import numpy as np
 import pandas as pd
 
 from .extractors import ModelExtractor, get_extractor
 from .mtable import MTable
+
+HeadOrder = Literal["dh", "hd", "d", "h", ""]
+StatsOrder = Literal["cs", "sc", "c", "s", ""]
 
 
 class ETable(MTable):
@@ -59,6 +62,10 @@ class ETable(MTable):
         custom_stats[key][i] is a list aligned to model i’s coefficient index.
     custom_model_stats : dict, optional
         Additional bottom rows. Shape: {'Row label': [val_m1, val_m2, ...]}.
+    stats_order : {"cs","sc","c","s",""}, optional
+        Bottom-panel order: c=custom model statistics, s=model statistics.
+        ``"cs"`` preserves the default behavior of showing custom statistics first.
+        A single letter displays only that block; ``""`` hides both blocks.
     keep : list[str] | str, optional
         Regex patterns (or exact names with exact_match=True) to keep and order
         coefficients. If provided, output order follows the pattern order.
@@ -135,6 +142,7 @@ class ETable(MTable):
     DEFAULT_SIGNIF_CODE: ClassVar[list[float]] = [0.01, 0.05, 0.10]
     DEFAULT_COEF_FMT: ClassVar[str] = "b:.3f* \n (se:.3f)"
     DEFAULT_MODEL_STATS: ClassVar[list[str]] = ["N", "r2"]
+    DEFAULT_STATS_ORDER: ClassVar[StatsOrder] = "cs"
     # Canonical stat key -> printable label (used if model_stats_labels is None)
     DEFAULT_STAT_LABELS: ClassVar[dict[str, str]] = {
         "N": "Observations",
@@ -163,7 +171,7 @@ class ETable(MTable):
     }
     DEFAULT_SHOW_SE_TYPE = True
     DEFAULT_SHOW_FE = True
-    DEFAULT_HEAD_ORDER = "dh"
+    DEFAULT_HEAD_ORDER: ClassVar[HeadOrder] = "dh"
     DEFAULT_FELABELS: ClassVar[dict[str, str]] = {}
     DEFAULT_CAT_TEMPLATE = "{variable}={value}"
     DEFAULT_LINEBREAK = "\n"
@@ -179,6 +187,7 @@ class ETable(MTable):
         model_stats_labels: dict[str, str] | None = None,
         custom_stats: dict | None = None,
         custom_model_stats: dict | None = None,
+        stats_order: StatsOrder | None = None,
         keep: list | str | None = None,
         drop: list | str | None = None,
         exact_match: bool | None = False,
@@ -190,7 +199,7 @@ class ETable(MTable):
         felabels: dict | None = None,
         notes: str = "",
         model_heads: list | None = None,
-        head_order: str | None = None,
+        head_order: HeadOrder | None = None,
         caption: str | None = None,
         tab_label: str | None = None,
         digits: int | None = None,
@@ -219,6 +228,7 @@ class ETable(MTable):
         show_fe = self.DEFAULT_SHOW_FE if show_fe is None else show_fe
         felabels = dict(self.DEFAULT_FELABELS) if felabels is None else felabels
         head_order = self.DEFAULT_HEAD_ORDER if head_order is None else head_order
+        stats_order = self.DEFAULT_STATS_ORDER if stats_order is None else stats_order
         custom_stats = {} if custom_stats is None else custom_stats
         keep = [] if keep is None else keep
         drop = [] if drop is None else drop
@@ -254,6 +264,7 @@ class ETable(MTable):
 
 
         assert head_order in ["dh", "hd", "d", "h", ""]
+        assert stats_order in ["cs", "sc", "c", "s", ""]
 
         # --- metadata from models (modular) ---
         dep_var_list = [self._extract_depvar(m) for m in models]
@@ -337,6 +348,7 @@ class ETable(MTable):
             stat_keys=model_stats,
             stat_labels=model_stats_labels,
             custom_model_stats=custom_model_stats,
+            stats_order=stats_order,
             like_index=res.index,
             like_columns=res.columns,
         )
@@ -641,6 +653,7 @@ class ETable(MTable):
         stat_keys: list[str],
         stat_labels: dict[str, str] | None,
         custom_model_stats: dict[str, list] | None,
+        stats_order: StatsOrder,
         like_index: pd.Index,
         like_columns: pd.Index,
     ) -> pd.DataFrame:
@@ -675,12 +688,9 @@ class ETable(MTable):
             else pd.DataFrame()
         )
 
-        if not custom_df.empty and not builtin_df.empty:
-            out = pd.concat([custom_df, builtin_df], axis=0)
-        elif not custom_df.empty:
-            out = custom_df
-        else:
-            out = builtin_df
+        blocks = {"c": custom_df, "s": builtin_df}
+        selected_blocks = [blocks[key] for key in stats_order if not blocks[key].empty]
+        out = pd.concat(selected_blocks, axis=0) if selected_blocks else pd.DataFrame()
 
         if out.shape[1] == 0:
             out = pd.DataFrame(
@@ -694,7 +704,7 @@ class ETable(MTable):
         self,
         dep_var_list: list[str],
         model_heads: list[str] | None,
-        head_order: str,
+        head_order: HeadOrder,
         n_models: int,
     ) -> list[str] | pd.MultiIndex:
         id_dep = dep_var_list

--- a/tests/api/test_stats.py
+++ b/tests/api/test_stats.py
@@ -68,6 +68,37 @@ class TestETableModelStats:
         table = mt.ETable([fitted_model], model_stats=["N", "aic", "bic"])
         assert table.make(type="tex") == snapshot
 
+    @pytest.mark.parametrize(
+        ("stats_order", "expected_rows"),
+        [
+            (None, ["Average", "Observations", "R²"]),
+            ("cs", ["Average", "Observations", "R²"]),
+            ("sc", ["Observations", "R²", "Average"]),
+            ("c", ["Average"]),
+            ("s", ["Observations", "R²"]),
+            ("", []),
+        ],
+    )
+    def test_stats_order(self, fitted_model, stats_order, expected_rows):
+        """Order or hide built-in and custom model-statistic blocks."""
+        table = mt.ETable(
+            [fitted_model],
+            model_stats=["N", "r2"],
+            custom_model_stats={"Average": [1.23]},
+            stats_order=stats_order,
+        )
+
+        if "stats" not in table.df.index.get_level_values(0):
+            actual_rows = []
+        else:
+            actual_rows = table.df.xs("stats").index.tolist()
+        assert actual_rows == expected_rows
+
+    def test_stats_order_rejects_invalid_value(self, fitted_model):
+        """Reject unsupported model-statistic block orders."""
+        with pytest.raises(AssertionError):
+            mt.ETable([fitted_model], stats_order="invalid")
+
 
 class TestBTableStats:
     """Snapshot tests for BTable statistics."""


### PR DESCRIPTION
Closes #60. This PR adds `stats_order` to `maketables.Etable` to make the order of `model_stats` and `custom_model_stats` blocks configurable.


For example,

```python
import pandas as pd
import statsmodels.formula.api as smf

import maketables as mt

df = pd.DataFrame(
  {
      "y": [1.0, 2.0, 2.5, 4.0, 5.5],
      "x": [0.0, 1.0, 2.0, 3.0, 4.0],
  }
)

model = smf.ols("y ~ x", data=df).fit()

table = mt.ETable(
  [model],
  model_stats=["N", "r2", "rmse"],
  custom_model_stats={
      "Average": [f"{df['y'].mean():.2f}"],
  },
  stats_order="sc",
)
print(table.df.loc["stats"])
```